### PR TITLE
improve: 型安全性強化 — Branded UUID 型・Zod バリデーション・定数化

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,42 @@ bun run setup   # pre-commit hook をインストール (lint + typecheck が co
 - 実装完了後, Issue にコメントで報告する
 - PR の description に `Closes #N` を記載して Issue と紐付ける
 
+## コーディング規約
+
+### 1. 原始型エイリアス
+
+原始型 (`string`, `number` など) をそのまま使わず, 意味的なエイリアスを定義する.
+
+```typescript
+export type NodeContent = string;
+export type EdgeLabel = string;
+export type FileName = string;
+export type SheetName = string;
+```
+
+### 2. ID には Branded UUID 型
+
+ID フィールドには Zod の `.brand()` を使って branded UUID 型を定義する.
+異なるエンティティの ID を混同しないよう, エンティティごとに異なる型とする.
+- Zod スキーマで UUID フォーマットを強制し, API 境界でバリデーションする
+- ドメイン内部の境界 (React Flow など) では `as NodeId` のキャストを使う
+
+```typescript
+export const NodeIdSchema = z.string().uuid().brand<'NodeId'>();
+export type NodeId = z.infer<typeof NodeIdSchema>;
+// EdgeId, SheetId, FileId も同様
+```
+
+### 3. 固定値は定数として定義する
+
+マジックリテラル (文字列・数値の直書き) は使わず, 名前付き定数として定義する.
+
+```typescript
+const SERVER_PORT = 3000;
+const DEFAULT_FILE_NAME = '無題';
+const DEFAULT_SHEET_NAME = 'Sheet 1';
+```
+
 ## コードレビュー基準
 
 優先度の高い順に

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,6 @@
       "name": "conversensus",
       "devDependencies": {
         "@biomejs/biome": "^2.4.7",
-        "@rollup/rollup-darwin-arm64": "^4.59.0",
       },
     },
     "src/client": {
@@ -40,6 +39,9 @@
     "src/shared": {
       "name": "@conversensus/shared",
       "version": "0.0.1",
+      "dependencies": {
+        "zod": "^3.24.0",
+      },
     },
   },
   "packages": {
@@ -350,6 +352,8 @@
     "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
   }

--- a/src/client/src/api.ts
+++ b/src/client/src/api.ts
@@ -1,17 +1,23 @@
-import type { GraphFile, GraphFileListItem } from '@conversensus/shared';
+import {
+  type GraphFile,
+  type GraphFileListItem,
+  GraphFileListItemSchema,
+  GraphFileSchema,
+} from '@conversensus/shared';
+import { z } from 'zod';
 
-const BASE = 'http://localhost:3000';
+const BASE = import.meta.env.VITE_API_BASE ?? 'http://localhost:3000';
 
 export async function fetchFiles(): Promise<GraphFileListItem[]> {
   const res = await fetch(`${BASE}/files`);
   if (!res.ok) throw new Error('Failed to fetch files');
-  return res.json();
+  return z.array(GraphFileListItemSchema).parse(await res.json());
 }
 
 export async function fetchFile(id: string): Promise<GraphFile> {
   const res = await fetch(`${BASE}/files/${id}`);
   if (!res.ok) throw new Error('Failed to fetch file');
-  return res.json();
+  return GraphFileSchema.parse(await res.json());
 }
 
 export async function createFile(name: string): Promise<GraphFile> {
@@ -21,7 +27,7 @@ export async function createFile(name: string): Promise<GraphFile> {
     body: JSON.stringify({ name }),
   });
   if (!res.ok) throw new Error('Failed to create file');
-  return res.json();
+  return GraphFileSchema.parse(await res.json());
 }
 
 export async function saveFile(file: GraphFile): Promise<GraphFile> {
@@ -31,7 +37,7 @@ export async function saveFile(file: GraphFile): Promise<GraphFile> {
     body: JSON.stringify(file),
   });
   if (!res.ok) throw new Error('Failed to save file');
-  return res.json();
+  return GraphFileSchema.parse(await res.json());
 }
 
 export async function removeFile(id: string): Promise<void> {

--- a/src/client/src/graphTransform.test.ts
+++ b/src/client/src/graphTransform.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'bun:test';
-import type { GraphEdge, GraphNode } from '@conversensus/shared';
+import type {
+  EdgeId,
+  GraphEdge,
+  GraphNode,
+  NodeId,
+} from '@conversensus/shared';
 import type { Edge, Node } from '@xyflow/react';
 import {
   fromFlowEdges,
@@ -9,9 +14,9 @@ import {
 } from './graphTransform';
 
 const graphNodes: GraphNode[] = [
-  { id: 'n1', content: 'ノード1', position: { x: 10, y: 20 } },
+  { id: 'n1' as NodeId, content: 'ノード1', position: { x: 10, y: 20 } },
   {
-    id: 'n2',
+    id: 'n2' as NodeId,
     content: 'ノード2',
     position: { x: 100, y: 200 },
     style: { color: 'red' },
@@ -19,8 +24,13 @@ const graphNodes: GraphNode[] = [
 ];
 
 const graphEdges: GraphEdge[] = [
-  { id: 'e1', source: 'n1', target: 'n2', label: 'ラベル' },
-  { id: 'e2', source: 'n2', target: 'n1' },
+  {
+    id: 'e1' as EdgeId,
+    source: 'n1' as NodeId,
+    target: 'n2' as NodeId,
+    label: 'ラベル',
+  },
+  { id: 'e2' as EdgeId, source: 'n2' as NodeId, target: 'n1' as NodeId },
 ];
 
 describe('toFlowNodes', () => {

--- a/src/client/src/graphTransform.ts
+++ b/src/client/src/graphTransform.ts
@@ -1,4 +1,9 @@
-import type { GraphEdge, GraphNode } from '@conversensus/shared';
+import type {
+  EdgeId,
+  GraphEdge,
+  GraphNode,
+  NodeId,
+} from '@conversensus/shared';
 import type { Edge, Node } from '@xyflow/react';
 
 export function toFlowNodes(nodes: GraphNode[]): Node[] {
@@ -18,9 +23,10 @@ export function toFlowEdges(edges: GraphEdge[]): Edge[] {
   }));
 }
 
+// React Flow boundary: ids are plain strings, cast to branded types
 export function fromFlowNodes(nodes: Node[]): GraphNode[] {
   return nodes.map((n) => ({
-    id: n.id,
+    id: n.id as NodeId,
     content: String(n.data.label ?? ''),
     position: n.position,
   }));
@@ -28,9 +34,9 @@ export function fromFlowNodes(nodes: Node[]): GraphNode[] {
 
 export function fromFlowEdges(edges: Edge[]): GraphEdge[] {
   return edges.map((e) => ({
-    id: e.id,
-    source: e.source,
-    target: e.target,
+    id: e.id as EdgeId,
+    source: e.source as NodeId,
+    target: e.target as NodeId,
     label: typeof e.label === 'string' ? e.label : undefined,
   }));
 }

--- a/src/server/src/index.ts
+++ b/src/server/src/index.ts
@@ -1,8 +1,19 @@
 import { randomUUID } from 'node:crypto';
-import type { GraphFile } from '@conversensus/shared';
+import {
+  CreateFileRequestSchema,
+  type FileId,
+  type GraphFile,
+  type SheetId,
+  UpdateFileRequestSchema,
+} from '@conversensus/shared';
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { deleteFile, listFiles, readFile, writeFile } from './storage';
+
+const SERVER_PORT = 3000;
+const LOCALHOST_ORIGIN_PREFIX = 'http://localhost:';
+const DEFAULT_FILE_NAME = '無題';
+const DEFAULT_SHEET_NAME = 'Sheet 1';
 
 const app = new Hono();
 
@@ -10,9 +21,14 @@ app.use(
   '*',
   cors({
     origin: (origin) =>
-      origin?.startsWith('http://localhost:') ? origin : null,
+      origin?.startsWith(LOCALHOST_ORIGIN_PREFIX) ? origin : null,
   }),
 );
+
+app.onError((err, c) => {
+  console.error(err);
+  return c.json({ error: 'Internal server error' }, 500);
+});
 
 // GET /files - ファイル一覧
 app.get('/files', async (c) => {
@@ -22,15 +38,20 @@ app.get('/files', async (c) => {
 
 // POST /files - 新規ファイル作成
 app.post('/files', async (c) => {
-  const body = await c.req.json<Partial<GraphFile>>();
-  const id = randomUUID();
+  const raw = await c.req.json().catch(() => null);
+  const parsed = CreateFileRequestSchema.safeParse(raw);
+  if (!parsed.success) {
+    return c.json({ error: parsed.error.flatten() }, 400);
+  }
+  const body = parsed.data;
+  const id = randomUUID() as FileId;
   const data: GraphFile = {
     id,
-    name: body.name ?? '無題',
+    name: body.name ?? DEFAULT_FILE_NAME,
     description: body.description,
     sheet: {
-      id: randomUUID(),
-      name: body.sheet?.name ?? 'Sheet 1',
+      id: randomUUID() as SheetId,
+      name: body.sheet?.name ?? DEFAULT_SHEET_NAME,
       nodes: [],
       edges: [],
     },
@@ -51,8 +72,12 @@ app.put('/files/:id', async (c) => {
   const id = c.req.param('id');
   const existing = await readFile(id);
   if (!existing) return c.json({ error: 'Not found' }, 404);
-  const body = await c.req.json<GraphFile>();
-  const data: GraphFile = { ...body, id };
+  const raw = await c.req.json().catch(() => null);
+  const parsed = UpdateFileRequestSchema.safeParse(raw);
+  if (!parsed.success) {
+    return c.json({ error: parsed.error.flatten() }, 400);
+  }
+  const data: GraphFile = { ...parsed.data, id: existing.id };
   await writeFile(data);
   return c.json(data);
 });
@@ -65,8 +90,8 @@ app.delete('/files/:id', async (c) => {
 });
 
 export default {
-  port: 3000,
+  port: SERVER_PORT,
   fetch: app.fetch,
 };
 
-console.log('server running on http://localhost:3000');
+console.log(`server running on http://localhost:${SERVER_PORT}`);

--- a/src/server/src/storage.test.ts
+++ b/src/server/src/storage.test.ts
@@ -2,20 +2,35 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import type { GraphFile } from '@conversensus/shared';
+import type {
+  EdgeId,
+  FileId,
+  GraphFile,
+  NodeId,
+  SheetId,
+} from '@conversensus/shared';
 import { deleteFile, listFiles, readFile, writeFile } from './storage';
 
 let tmpDir: string;
 
 const sampleFile = (): GraphFile => ({
-  id: 'test-id-1',
+  id: 'test-id-1' as FileId,
   name: 'テストファイル',
   description: '説明',
   sheet: {
-    id: 'sheet-1',
+    id: 'sheet-1' as SheetId,
     name: 'Sheet 1',
-    nodes: [{ id: 'n1', content: 'ノード1', position: { x: 10, y: 20 } }],
-    edges: [{ id: 'e1', source: 'n1', target: 'n2', label: 'ラベル' }],
+    nodes: [
+      { id: 'n1' as NodeId, content: 'ノード1', position: { x: 10, y: 20 } },
+    ],
+    edges: [
+      {
+        id: 'e1' as EdgeId,
+        source: 'n1' as NodeId,
+        target: 'n2' as NodeId,
+        label: 'ラベル',
+      },
+    ],
   },
 });
 
@@ -63,8 +78,8 @@ describe('storage', () => {
     });
 
     it('複数ファイルをすべてリストアップする', async () => {
-      await writeFile({ ...sampleFile(), id: 'id-a', name: 'A' });
-      await writeFile({ ...sampleFile(), id: 'id-b', name: 'B' });
+      await writeFile({ ...sampleFile(), id: 'id-a' as FileId, name: 'A' });
+      await writeFile({ ...sampleFile(), id: 'id-b' as FileId, name: 'B' });
       const result = await listFiles();
       expect(result).toHaveLength(2);
       const ids = result.map((f) => f.id).sort();

--- a/src/shared/package.json
+++ b/src/shared/package.json
@@ -3,5 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "main": "./src/index.ts",
-  "types": "./src/index.ts"
+  "types": "./src/index.ts",
+  "dependencies": {
+    "zod": "^3.24.0"
+  }
 }

--- a/src/shared/src/index.ts
+++ b/src/shared/src/index.ts
@@ -1,34 +1,81 @@
-export type GraphNode = {
-  id: string;
-  content: string;
-  position: { x: number; y: number };
-  style?: Record<string, unknown>;
-};
+import { z } from 'zod';
 
-export type GraphEdge = {
-  id: string;
-  source: string;
-  target: string;
-  label?: string;
-  style?: Record<string, unknown>;
-};
+// --- Branded ID schemas (UUID enforced at API boundaries) ---
+export const NodeIdSchema = z.string().uuid().brand<'NodeId'>();
+export const EdgeIdSchema = z.string().uuid().brand<'EdgeId'>();
+export const SheetIdSchema = z.string().uuid().brand<'SheetId'>();
+export const FileIdSchema = z.string().uuid().brand<'FileId'>();
 
-export type Sheet = {
-  id: string;
-  name: string;
-  nodes: GraphNode[];
-  edges: GraphEdge[];
-};
+// --- Branded ID types ---
+export type NodeId = z.infer<typeof NodeIdSchema>;
+export type EdgeId = z.infer<typeof EdgeIdSchema>;
+export type SheetId = z.infer<typeof SheetIdSchema>;
+export type FileId = z.infer<typeof FileIdSchema>;
 
-export type GraphFile = {
-  id: string;
-  name: string;
-  description?: string;
-  sheet: Sheet;
-};
+// --- Primitive type aliases ---
+export type NodeContent = string;
+export type EdgeLabel = string;
+export type FileName = string;
+export type FileDescription = string;
+export type SheetName = string;
 
-export type GraphFileListItem = {
-  id: string;
-  name: string;
-  description?: string;
-};
+// --- Compound type schemas ---
+export const PositionSchema = z.object({ x: z.number(), y: z.number() });
+export type Position = z.infer<typeof PositionSchema>;
+
+export const StyleSchema = z.record(z.string(), z.unknown());
+export type Style = z.infer<typeof StyleSchema>;
+
+// --- Domain schemas ---
+export const GraphNodeSchema = z.object({
+  id: NodeIdSchema,
+  content: z.string(),
+  position: PositionSchema,
+  style: StyleSchema.optional(),
+});
+
+export const GraphEdgeSchema = z.object({
+  id: EdgeIdSchema,
+  source: NodeIdSchema,
+  target: NodeIdSchema,
+  label: z.string().optional(),
+  style: StyleSchema.optional(),
+});
+
+export const SheetSchema = z.object({
+  id: SheetIdSchema,
+  name: z.string(),
+  nodes: z.array(GraphNodeSchema),
+  edges: z.array(GraphEdgeSchema),
+});
+
+export const GraphFileSchema = z.object({
+  id: FileIdSchema,
+  name: z.string(),
+  description: z.string().optional(),
+  sheet: SheetSchema,
+});
+
+export const GraphFileListItemSchema = z.object({
+  id: FileIdSchema,
+  name: z.string(),
+  description: z.string().optional(),
+});
+
+// --- Domain types (inferred from schemas) ---
+export type GraphNode = z.infer<typeof GraphNodeSchema>;
+export type GraphEdge = z.infer<typeof GraphEdgeSchema>;
+export type Sheet = z.infer<typeof SheetSchema>;
+export type GraphFile = z.infer<typeof GraphFileSchema>;
+export type GraphFileListItem = z.infer<typeof GraphFileListItemSchema>;
+
+// --- HTTP API request/response schemas ---
+export const CreateFileRequestSchema = z.object({
+  name: z.string().optional(),
+  description: z.string().optional(),
+  sheet: z.object({ name: z.string().optional() }).optional(),
+});
+export type CreateFileRequest = z.infer<typeof CreateFileRequestSchema>;
+
+export const UpdateFileRequestSchema = GraphFileSchema;
+export type UpdateFileRequest = z.infer<typeof UpdateFileRequestSchema>;


### PR DESCRIPTION
## Summary

- **Branded UUID 型**: `NodeId` / `EdgeId` / `SheetId` / `FileId` を Zod `.brand()` で定義。エンティティ間の ID 混同をコンパイル時に防止
- **Zod バリデーション**: POST/PUT リクエストボディをスキーマ検証し不正入力を 400 で拒否。クライアント側もレスポンスを Zod でパース
- **型エイリアス**: `NodeContent` / `EdgeLabel` / `FileName` 等の意味的エイリアスを定義
- **定数化**: `SERVER_PORT` / `DEFAULT_FILE_NAME` / `DEFAULT_SHEET_NAME` 等のマジックリテラルを排除
- **AGENTS.md**: 上記3点をコーディング規約として明記

## Test plan

- [x] `bun test` — 全30テストがパスすること
- [x] lint / typecheck がパスすること (pre-commit hook で確認済み)
- [x] 不正な JSON を POST/PUT に送ると 400 が返ること
- [x] 正常なリクエストで 201/200 が返り、レスポンスが Zod スキーマを満たすこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)