### PR TITLE
fix: パストラバーサル修正・タイマークリーンアップ・エラーハンドリング追加

### DIFF
--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -15,27 +15,46 @@ export default function App() {
     fetchFiles().then(setFiles).catch(console.error);
   }, []);
 
+  // アンマウント時にオートセーブタイマーをキャンセルする
+  useEffect(() => {
+    return () => {
+      if (saveTimer.current) clearTimeout(saveTimer.current);
+    };
+  }, []);
+
   const openFile = useCallback(async (id: string) => {
-    const file = await fetchFile(id);
-    setActiveFile(file);
+    try {
+      const file = await fetchFile(id);
+      setActiveFile(file);
+    } catch (err) {
+      console.error('Failed to open file:', err);
+    }
   }, []);
 
   const handleCreate = useCallback(async () => {
-    const name = newFileName.trim() || '無題';
-    const file = await createFile(name);
-    setFiles((fs) => [
-      ...fs,
-      { id: file.id, name: file.name, description: file.description },
-    ]);
-    setActiveFile(file);
-    setNewFileName('');
+    try {
+      const name = newFileName.trim() || '無題';
+      const file = await createFile(name);
+      setFiles((fs) => [
+        ...fs,
+        { id: file.id, name: file.name, description: file.description },
+      ]);
+      setActiveFile(file);
+      setNewFileName('');
+    } catch (err) {
+      console.error('Failed to create file:', err);
+    }
   }, [newFileName]);
 
   const handleDelete = useCallback(
     async (id: string) => {
-      await removeFile(id);
-      setFiles((fs) => fs.filter((f) => f.id !== id));
-      if (activeFile?.id === id) setActiveFile(null);
+      try {
+        await removeFile(id);
+        setFiles((fs) => fs.filter((f) => f.id !== id));
+        if (activeFile?.id === id) setActiveFile(null);
+      } catch (err) {
+        console.error('Failed to delete file:', err);
+      }
     },
     [activeFile],
   );
@@ -44,18 +63,22 @@ export default function App() {
     setActiveFile(updated);
     if (saveTimer.current) clearTimeout(saveTimer.current);
     saveTimer.current = setTimeout(async () => {
-      await saveFile(updated);
-      setFiles((fs) =>
-        fs.map((f) =>
-          f.id === updated.id
-            ? {
-                id: updated.id,
-                name: updated.name,
-                description: updated.description,
-              }
-            : f,
-        ),
-      );
+      try {
+        await saveFile(updated);
+        setFiles((fs) =>
+          fs.map((f) =>
+            f.id === updated.id
+              ? {
+                  id: updated.id,
+                  name: updated.name,
+                  description: updated.description,
+                }
+              : f,
+          ),
+        );
+      } catch (err) {
+        console.error('Failed to save file:', err);
+      }
     }, AUTOSAVE_DELAY);
   }, []);
 

--- a/src/server/src/storage.ts
+++ b/src/server/src/storage.ts
@@ -1,12 +1,18 @@
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import type { GraphFile, GraphFileListItem } from '@conversensus/shared';
 
 function dataDir() {
   return process.env.DATA_DIR ?? join(import.meta.dir, '../../../data');
 }
 
+// パストラバーサル対策: id に使用できる文字を制限し, dataDir 外へのパスを拒否する
 function filePath(id: string) {
-  return join(dataDir(), `${id}.json`);
+  if (!/^[a-zA-Z0-9_-]+$/.test(id)) throw new Error('Invalid file ID');
+  const dir = resolve(dataDir());
+  const resolved = resolve(dir, `${id}.json`);
+  if (!resolved.startsWith(dir + '/') && resolved !== dir)
+    throw new Error('Path traversal detected');
+  return resolved;
 }
 
 export async function listFiles(): Promise<GraphFileListItem[]> {


### PR DESCRIPTION
## Summary

- **[CRITICAL] パストラバーサル脆弱性修正** (`storage.ts`): `filePath()` で `id` を英数字・ハイフン・アンダースコアのみに制限し、`resolve()` で `dataDir()` 外へのパス解決を拒否
- **[MEDIUM] オートセーブタイマークリーンアップ** (`App.tsx`): アンマウント時に `clearTimeout` で未発火のタイマーをキャンセル
- **[MEDIUM] 非同期イベントハンドラのエラーハンドリング** (`App.tsx`): `openFile` / `handleCreate` / `handleDelete` / autosave callback に `try-catch` を追加

## Test plan

- [x] `bun test` — 全30テストがパスすること
- [x] `../../etc/passwd` などのパストラバーサル ID が `Invalid file ID` エラーになること
- [x] lint / typecheck がパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)