### PR TITLE
test: EditableLabelEdge のユニットテストを追加

### DIFF
--- a/src/client/src/EditableLabelEdge.test.md
+++ b/src/client/src/EditableLabelEdge.test.md
@@ -1,0 +1,29 @@
+# EditableLabelEdge テスト仕様
+
+## 何をテストするか
+
+`EditableLabelEdge` カスタム edge コンポーネントのインタラクション動作。
+
+## なぜテストするか
+
+- ダブルクリック→インライン編集→確定/キャンセルの状態遷移は UI の核心機能
+- IME (日本語入力) の Enter 誤確定バグは発生しやすく, 回帰しやすい
+- `setEdges` の呼び出し有無でビジネスロジック（永続化フロー）の正確性を担保する
+
+## どのようにテストするか
+
+`@testing-library/react` + `happy-dom` で DOM 環境を構築。
+`@xyflow/react` を `mock.module()` でスタブ化し, `useReactFlow().setEdges` の呼び出しを検証。
+`EdgeLabelRenderer` はポータルをバイパスして children を直接レンダリングするスタブに差し替える。
+
+| テストケース | 検証内容 |
+|---|---|
+| ラベルを表示する | `label` が span として描画される |
+| ラベルが空/未定義の場合は span を表示しない | 空の button が描画されるが textbox は現れない |
+| ラベルをダブルクリックで編集モードに切り替わる | dblclick 後に textbox が出現し value が現在のラベル |
+| ラベルなしでもボタンのダブルクリックで編集モードに切り替わる | 空ラベルでも button をクリックすれば編集できる |
+| Enter で確定し setEdges を呼び出す | `setEdges` が 1 回呼ばれ, input が消える |
+| Escape でキャンセルし setEdges を呼ばない | `setEdges` が呼ばれず, input が消える |
+| onBlur で確定し setEdges を呼び出す | blur 時に `setEdges` が呼ばれ, input が消える |
+| IME 変換中は Enter で確定しない | `compositionStart` 後の Enter は無視される |
+| compositionEnd 後は Enter で確定できる | `compositionEnd` 後の Enter で `setEdges` が呼ばれる |

--- a/src/client/src/EditableLabelEdge.test.tsx
+++ b/src/client/src/EditableLabelEdge.test.tsx
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import type { ReactNode } from 'react';
+
+// bun では mock.module() はホイストされないため, await import() の前に呼ぶことで
+// EditableLabelEdge が @xyflow/react を読み込む前にモックを登録できる
+const mockSetEdges = mock((_updater: unknown) => {});
+
+mock.module('@xyflow/react', () => ({
+  BaseEdge: () => null,
+  // EdgeLabelRenderer はポータルで描画するため, テスト用に children を直接レンダリング
+  EdgeLabelRenderer: ({ children }: { children: ReactNode }) => <>{children}</>,
+  getBezierPath: () => ['M0,0 L100,100', 50, 50],
+  useReactFlow: () => ({ setEdges: mockSetEdges }),
+}));
+
+const { render, screen, fireEvent, cleanup } = await import(
+  '@testing-library/react'
+);
+const { EditableLabelEdge } = await import('./EditableLabelEdge');
+
+// EdgeProps の最小スタブ
+// biome-ignore lint/suspicious/noExplicitAny: テスト用 EdgeProps スタブ
+type TestEdgeProps = any;
+const makeProps = (label?: string): TestEdgeProps => ({
+  id: 'edge-1',
+  label,
+  sourceX: 0,
+  sourceY: 0,
+  targetX: 100,
+  targetY: 100,
+  sourcePosition: 'bottom',
+  targetPosition: 'top',
+  markerEnd: undefined,
+  style: undefined,
+});
+
+describe('EditableLabelEdge', () => {
+  beforeEach(() => {
+    mockSetEdges.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('ラベルを表示する', () => {
+    render(<EditableLabelEdge {...makeProps('テストラベル')} />);
+    expect(screen.getByText('テストラベル')).toBeDefined();
+  });
+
+  it('ラベルが空/未定義の場合は span を表示しない', () => {
+    render(<EditableLabelEdge {...makeProps()} />);
+    expect(screen.queryByRole('textbox')).toBeNull();
+    // ラベルテキストが存在しないことを確認 (button 自体は描画される)
+    expect(screen.getByRole('button').textContent).toBe('');
+  });
+
+  it('ラベルをダブルクリックで編集モードに切り替わる', () => {
+    render(<EditableLabelEdge {...makeProps('テストラベル')} />);
+    fireEvent.dblClick(screen.getByText('テストラベル'));
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    expect(input).toBeDefined();
+    expect(input.value).toBe('テストラベル');
+  });
+
+  it('ラベルなしでもボタンのダブルクリックで編集モードに切り替わる', () => {
+    render(<EditableLabelEdge {...makeProps()} />);
+    fireEvent.dblClick(screen.getByRole('button'));
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    expect(input).toBeDefined();
+    expect(input.value).toBe('');
+  });
+
+  it('Enter で確定し setEdges を呼び出す', () => {
+    render(<EditableLabelEdge {...makeProps('テストラベル')} />);
+    fireEvent.dblClick(screen.getByText('テストラベル'));
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '新しいラベル' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(mockSetEdges).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('textbox')).toBeNull();
+  });
+
+  it('Escape でキャンセルし setEdges を呼ばない', () => {
+    render(<EditableLabelEdge {...makeProps('テストラベル')} />);
+    fireEvent.dblClick(screen.getByText('テストラベル'));
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '変更しない' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(mockSetEdges).not.toHaveBeenCalled();
+    expect(screen.queryByRole('textbox')).toBeNull();
+  });
+
+  it('onBlur で確定し setEdges を呼び出す', () => {
+    render(<EditableLabelEdge {...makeProps('テストラベル')} />);
+    fireEvent.dblClick(screen.getByText('テストラベル'));
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '変更内容' } });
+    fireEvent.blur(input);
+    expect(mockSetEdges).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('textbox')).toBeNull();
+  });
+
+  it('IME 変換中 (compositionStart 後) は Enter で確定しない', () => {
+    render(<EditableLabelEdge {...makeProps('テストラベル')} />);
+    fireEvent.dblClick(screen.getByText('テストラベル'));
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    fireEvent.compositionStart(input);
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(mockSetEdges).not.toHaveBeenCalled();
+    expect(screen.getByRole('textbox')).toBeDefined(); // まだ編集中
+  });
+
+  it('compositionEnd 後は Enter で確定できる', () => {
+    render(<EditableLabelEdge {...makeProps('テストラベル')} />);
+    fireEvent.dblClick(screen.getByText('テストラベル'));
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    fireEvent.compositionStart(input);
+    fireEvent.compositionEnd(input);
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(mockSetEdges).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- `EditableLabelEdge.test.tsx` に 9 件のユニットテストを追加
- `EditableLabelEdge.test.md` にテスト仕様を記述
- `@xyflow/react` を `mock.module()` でスタブ化（`EdgeLabelRenderer` はポータルをバイパスして children を直接レンダリング）

**カバー範囲:**
- ラベル表示 / 空ラベル
- ダブルクリックで編集モード開始
- Enter/Escape/blur による確定・キャンセル
- IME 変換中の Enter 無視、compositionEnd 後の確定

## Test plan

- [x] テスト 47/47 パス
- [x] Biome lint クリア
- [x] TypeScript 型エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)