### PR TITLE
feat: node の左右辺にも接続ポイントを追加 (issue #6)

### DIFF
--- a/src/client/src/EditableNode.tsx
+++ b/src/client/src/EditableNode.tsx
@@ -30,7 +30,9 @@ export function EditableNode({ id, data }: NodeProps) {
 
   return (
     <>
-      <Handle type="target" position={Position.Top} />
+      <Handle type="target" position={Position.Top} id="target-top" />
+      <Handle type="target" position={Position.Left} id="target-left" />
+      <Handle type="target" position={Position.Right} id="target-right" />
       {/* biome-ignore lint/a11y/noStaticElementInteractions: ノードコンテナはダブルクリックで編集を開始する */}
       <div
         style={{
@@ -82,7 +84,9 @@ export function EditableNode({ id, data }: NodeProps) {
           </span>
         )}
       </div>
-      <Handle type="source" position={Position.Bottom} />
+      <Handle type="source" position={Position.Bottom} id="source-bottom" />
+      <Handle type="source" position={Position.Left} id="source-left" />
+      <Handle type="source" position={Position.Right} id="source-right" />
     </>
   );
 }


### PR DESCRIPTION
## Summary

- `EditableNode` に Left/Right の `target` および `source` Handle を追加
- 複数ハンドルを区別するため全ハンドルに ID を付与 (`target-top`, `target-left`, `target-right`, `source-bottom`, `source-left`, `source-right`)

Closes #6

## Test plan

- [x] テスト 47/47 パス
- [x] Biome lint クリア
- [x] 左右辺から edge を引き出せることを手動確認
- [x] 左右辺への edge 接続が可能なことを手動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)