### PR TITLE
feat: ノード中心間接続に変更、明示的ハンドルを廃止 (issue #24)

### DIFF
--- a/src/client/src/EditableNode.tsx
+++ b/src/client/src/EditableNode.tsx
@@ -46,9 +46,17 @@ export function EditableNode({ id, data, selected }: NodeProps) {
   return (
     <>
       <NodeResizer isVisible={selected} minWidth={80} minHeight={40} />
-      <Handle type="target" position={Position.Top} id="target-top" />
-      <Handle type="target" position={Position.Left} id="target-left" />
-      <Handle type="target" position={Position.Right} id="target-right" />
+      <Handle
+        type="source"
+        position={Position.Top}
+        id="center"
+        style={{
+          left: '50%',
+          top: '50%',
+          transform: 'translate(-50%, -50%)',
+          opacity: 0,
+        }}
+      />
       {/* biome-ignore lint/a11y/noStaticElementInteractions: ノードコンテナはダブルクリックで編集を開始する */}
       <div
         style={{
@@ -104,9 +112,6 @@ export function EditableNode({ id, data, selected }: NodeProps) {
           </div>
         )}
       </div>
-      <Handle type="source" position={Position.Bottom} id="source-bottom" />
-      <Handle type="source" position={Position.Left} id="source-left" />
-      <Handle type="source" position={Position.Right} id="source-right" />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- 上下左右の6ハンドルを削除し、ノード中央に単一の不可視ハンドルを配置
- `connectionMode=loose` により source/target 兼用で動作
- エッジはノード中心間を接続する形に変更

## 設計方針
port 概念が必要になった場合は `port` 種別ノードとして実装する方針（issue #24 記載）

## Test plan
- [x] ノード同士をドラッグして接続できる
- [x] ハンドルが UI 上に表示されない
- [ ] エッジの reconnect が動作する
- [ ] ノードのダブルクリック編集が引き続き動作する

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)