### PR TITLE
feat(copy-paste): Cmd+C/V でノード・エッジのコピー/ペーストを実装 (issue #30)

### DIFF
--- a/src/client/src/GraphEditor.tsx
+++ b/src/client/src/GraphEditor.tsx
@@ -46,7 +46,7 @@ type Props = {
 };
 
 function GraphEditorInner({ file, onChange }: Props) {
-  const { screenToFlowPosition } = useReactFlow();
+  const { screenToFlowPosition, getNodes, getEdges } = useReactFlow();
   const [nodes, setNodes, onNodesChange] = useNodesState(
     toFlowNodes(file.sheet.nodes),
   );
@@ -252,15 +252,9 @@ function GraphEditorInner({ file, onChange }: Props) {
   const clipboard = useRef<{ nodes: Node[]; edges: Edge[] } | null>(null);
 
   const copySelectedNodes = useCallback(() => {
-    setNodes((ns) => {
-      setEdges((es) => {
-        const copied = collectCopyData(ns, es);
-        if (copied.nodes.length > 0) clipboard.current = copied;
-        return es;
-      });
-      return ns;
-    });
-  }, [setNodes, setEdges]);
+    const copied = collectCopyData(getNodes(), getEdges());
+    if (copied.nodes.length > 0) clipboard.current = copied;
+  }, [getNodes, getEdges]);
 
   const pasteNodes = useCallback(() => {
     if (!clipboard.current) return;
@@ -278,9 +272,12 @@ function GraphEditorInner({ file, onChange }: Props) {
   }, [setNodes, setEdges]);
 
   // Cmd+C / Ctrl+C でコピー, Cmd+V / Ctrl+V でペースト
+  // INPUT / TEXTAREA 編集中は標準のクリップボード操作を妨げない
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (!(e.metaKey || e.ctrlKey)) return;
+      const tag = (e.target as HTMLElement)?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA') return;
       if (e.key === 'c') {
         e.preventDefault();
         copySelectedNodes();

--- a/src/client/src/graphTransform.test.ts
+++ b/src/client/src/graphTransform.test.ts
@@ -537,4 +537,28 @@ describe('buildPastedData', () => {
     const { nodes } = buildPastedData(clipboard, 0);
     expect(nodes[0].parentId).toBeUndefined();
   });
+
+  it('コピーセット内の親子ノードで子にはオフセットを適用しない', () => {
+    const parent = makeNode('g1', true); // position { x:10, y:20 }
+    const child = makeNode('n1', true, 'g1'); // position { x:10, y:20 } (relative)
+    const clipboard = { nodes: [parent, child], edges: [] };
+    const { nodes } = buildPastedData(clipboard, 30);
+    const newParent = nodes.find((n) => n.data.label === 'g1');
+    const newChild = nodes.find((n) => n.data.label === 'n1');
+    // 親のみオフセット: 10+30=40, 20+30=50
+    expect(newParent?.position).toEqual({ x: 40, y: 50 });
+    // 子は相対座標のままオフセットなし
+    expect(newChild?.position).toEqual({ x: 10, y: 20 });
+  });
+
+  it('ペースト後のノード配列で親は子より前に並ぶ', () => {
+    const parent = makeNode('g1', true);
+    const child = makeNode('n1', true, 'g1');
+    // 意図的に子→親の順でクリップボードに入れる
+    const clipboard = { nodes: [child, parent], edges: [] };
+    const { nodes } = buildPastedData(clipboard, 0);
+    const parentIdx = nodes.findIndex((n) => n.data.label === 'g1');
+    const childIdx = nodes.findIndex((n) => n.data.label === 'n1');
+    expect(parentIdx).toBeLessThan(childIdx);
+  });
 });

--- a/src/client/src/graphTransform.ts
+++ b/src/client/src/graphTransform.ts
@@ -206,14 +206,37 @@ export function buildPastedData(
     clipboard.nodes.map((n) => [n.id, crypto.randomUUID()]),
   );
 
-  const nodes: Node[] = clipboard.nodes.map((n) => ({
-    ...n,
-    id: idMap.get(n.id) as string,
-    // parentId がコピーセット内にある場合は新 ID を使用, なければ root に配置
-    parentId: n.parentId ? idMap.get(n.parentId) : undefined,
-    selected: true,
-    position: { x: n.position.x + offset, y: n.position.y + offset },
-  }));
+  const mappedNodes: Node[] = clipboard.nodes.map((n) => {
+    const newParentId = n.parentId ? idMap.get(n.parentId) : undefined;
+    // 親がコピーセット内にある子ノードは相対座標のままオフセット不要
+    const applyOffset = !newParentId;
+    return {
+      ...n,
+      id: idMap.get(n.id) as string,
+      parentId: newParentId,
+      selected: true,
+      position: {
+        x: n.position.x + (applyOffset ? offset : 0),
+        y: n.position.y + (applyOffset ? offset : 0),
+      },
+    };
+  });
+
+  // React Flow は親ノードを子ノードより前に並べる必要があるため,
+  // parentId が解決済みの順にトポロジカルソートする
+  const sorted: Node[] = [];
+  const remaining = [...mappedNodes];
+  const addedIds = new Set<string>();
+  while (remaining.length > 0) {
+    const idx = remaining.findIndex(
+      (n) => !n.parentId || addedIds.has(n.parentId),
+    );
+    if (idx === -1) break; // 循環がある場合は残りをそのまま追加
+    const [node] = remaining.splice(idx, 1);
+    sorted.push(node);
+    addedIds.add(node.id);
+  }
+  sorted.push(...remaining);
 
   const edges: Edge[] = clipboard.edges.map((e) => ({
     ...e,
@@ -222,7 +245,7 @@ export function buildPastedData(
     target: idMap.get(e.target) as string,
   }));
 
-  return { nodes, edges };
+  return { nodes: sorted, edges };
 }
 
 export function fromFlowEdges(edges: Edge[]): GraphEdge[] {


### PR DESCRIPTION
## Summary

- `Cmd+C` / `Ctrl+C` で選択中のノードと選択ノード間のエッジをコピー
- `Cmd+V` / `Ctrl+V` で新規 UUID・+20px オフセットで貼り付け
- 複数ノード選択に対応
- グループノード選択時は子孫ノードも再帰的にコピー対象に含める
- 貼り付け後は新ノードのみ選択状態に変更（連続ペーストで毎回オフセット）
- グループ外への抽出ユースケース: コピー → 外で貼り付け → 元を削除

## 実装詳細

- `collectCopyData` / `buildPastedData` を `graphTransform.ts` に純粋関数として抽出
- `GraphEditor.tsx` のコールバックからこれらを呼び出すシンプルな構造

## Test plan

- [x] `graphTransform.test.ts` に 11 件のテストを追加（合計 40 件、全パス）
  - `collectCopyData`: 選択ノード抽出、エッジフィルタ、空ケース、グループ子孫展開、ネスト再帰
  - `buildPastedData`: UUID 再割り当て、オフセット、selected フラグ、エッジ更新、parentId 付け替え・解除
- [x] TypeScript チェック通過
- [x] Biome lint 通過

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)