### PR TITLE
refactor: GraphEditor custom hooks 抽出 + NodeStyle スキーマ構造化

### DIFF
--- a/src/client/src/GraphEditor.tsx
+++ b/src/client/src/GraphEditor.tsx
@@ -7,7 +7,6 @@ import {
   type Edge,
   MarkerType,
   MiniMap,
-  type Node,
   type OnConnect,
   type OnReconnect,
   Panel,
@@ -17,28 +16,24 @@ import {
   useNodesState,
   useReactFlow,
 } from '@xyflow/react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import '@xyflow/react/dist/style.css';
 import type { EdgePathType, GraphFile } from '@conversensus/shared';
 import { EditableLabelEdge } from './EditableLabelEdge';
 import { EditableNode } from './EditableNode';
 import { GroupNode } from './GroupNode';
 import {
-  buildPastedData,
-  collectCopyData,
   DEFAULT_NODE_STYLE,
   fromFlowEdges,
   fromFlowNodes,
-  GROUP_PADDING,
-  GROUP_TITLE_HEIGHT,
   recalculateParentBounds,
   toFlowEdges,
   toFlowNodes,
 } from './graphTransform';
-
-const DOUBLE_CLICK_INTERVAL_MS = 300;
-const DOUBLE_CLICK_THRESHOLD_PX = 5;
-const PASTE_OFFSET_PX = 20;
+import { useClipboard } from './hooks/useClipboard';
+import { useEdgeContextMenu } from './hooks/useEdgeContextMenu';
+import { useGroupNodes } from './hooks/useGroupNodes';
+import { usePaneDoubleClick } from './hooks/usePaneDoubleClick';
 
 type Props = {
   file: GraphFile;
@@ -123,7 +118,7 @@ function GraphEditorInner({ file, onChange }: Props) {
             id: crypto.randomUUID(),
             type: 'editableLabel',
             markerEnd: { type: MarkerType.ArrowClosed },
-            data: { pathType: 'bezier' },
+            data: { pathType: 'bezier' satisfies EdgePathType },
           },
           es,
         ),
@@ -152,238 +147,17 @@ function GraphEditorInner({ file, onChange }: Props) {
     [setNodes],
   );
 
-  const groupSelectedNodes = useCallback(() => {
-    setNodes((ns) => {
-      const selected = ns.filter((n) => n.selected);
-      if (selected.length < 1) return ns;
-
-      // 選択ノードが同じ親を持つ場合, その親の中にグループを作る
-      const sharedParentId = selected.every(
-        (n) => n.parentId === selected[0].parentId,
-      )
-        ? selected[0].parentId
-        : undefined;
-
-      // 選択ノードのバウンディングボックスを計算 (sharedParentId がある場合は相対座標)
-      const minX = Math.min(...selected.map((n) => n.position.x));
-      const minY = Math.min(...selected.map((n) => n.position.y));
-      const maxX = Math.max(
-        ...selected.map(
-          (n) =>
-            n.position.x +
-            Number(
-              n.measured?.width ?? n.style?.width ?? DEFAULT_NODE_STYLE.width,
-            ),
-        ),
-      );
-      const maxY = Math.max(
-        ...selected.map(
-          (n) =>
-            n.position.y +
-            Number(
-              n.measured?.height ??
-                n.style?.height ??
-                DEFAULT_NODE_STYLE.height,
-            ),
-        ),
-      );
-
-      const parentX = minX - GROUP_PADDING;
-      const parentY = minY - GROUP_PADDING - GROUP_TITLE_HEIGHT;
-      const parentWidth = maxX - minX + GROUP_PADDING * 2;
-      const parentHeight = maxY - minY + GROUP_PADDING * 2 + GROUP_TITLE_HEIGHT;
-      const parentId = crypto.randomUUID();
-
-      const parentNode = {
-        id: parentId,
-        position: { x: parentX, y: parentY },
-        data: { label: 'グループ' },
-        type: 'groupNode' as const,
-        parentId: sharedParentId,
-        style: { width: parentWidth, height: parentHeight, nodeType: 'group' },
-      };
-
-      const selectedIds = new Set(selected.map((n) => n.id));
-
-      const mappedNodes = ns.map((n) => {
-        if (!selectedIds.has(n.id)) return n;
-        return {
-          ...n,
-          parentId,
-          selected: false,
-          position: {
-            x: n.position.x - parentX,
-            y: n.position.y - parentY,
-          },
-        };
-      });
-
-      // React Flow では親ノードを子ノードより前に配置する必要がある
-      // ネスト時は sharedParentId の直後に挿入する
-      if (sharedParentId) {
-        const idx = mappedNodes.findIndex((n) => n.id === sharedParentId);
-        const insertAt = idx >= 0 ? idx + 1 : 0;
-        return [
-          ...mappedNodes.slice(0, insertAt),
-          parentNode,
-          ...mappedNodes.slice(insertAt),
-        ];
-      }
-
-      return [parentNode, ...mappedNodes];
-    });
-  }, [setNodes]);
-
-  // Cmd+G / Ctrl+G でグループ化
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === 'g') {
-        e.preventDefault();
-        groupSelectedNodes();
-      }
-    };
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
-  }, [groupSelectedNodes]);
-
   const onNodeDragStop = useCallback(() => {
     setNodes((ns) => recalculateParentBounds(ns));
   }, [setNodes]);
 
-  const clipboard = useRef<{ nodes: Node[]; edges: Edge[] } | null>(null);
-
-  const copySelectedNodes = useCallback(() => {
-    const copied = collectCopyData(getNodes(), getEdges());
-    if (copied.nodes.length > 0) clipboard.current = copied;
-  }, [getNodes, getEdges]);
-
-  const pasteNodes = useCallback(() => {
-    if (!clipboard.current) return;
-    const { nodes: newNodes, edges: newEdges } = buildPastedData(
-      clipboard.current,
-      PASTE_OFFSET_PX,
-    );
-    setNodes((ns) => [
-      ...ns.map((n) => ({ ...n, selected: false })),
-      ...newNodes,
-    ]);
-    setEdges((es) => [...es, ...newEdges]);
-    // 次の貼り付けがさらにオフセットされるようクリップボードを更新
-    clipboard.current = { nodes: newNodes, edges: newEdges };
-  }, [setNodes, setEdges]);
-
-  // Cmd+C / Ctrl+C でコピー, Cmd+V / Ctrl+V でペースト
-  // INPUT / TEXTAREA 編集中は標準のクリップボード操作を妨げない
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (!(e.metaKey || e.ctrlKey)) return;
-      const tag = (e.target as HTMLElement)?.tagName;
-      if (tag === 'INPUT' || tag === 'TEXTAREA') return;
-      if (e.key === 'c') {
-        e.preventDefault();
-        copySelectedNodes();
-      } else if (e.key === 'v') {
-        e.preventDefault();
-        pasteNodes();
-      }
-    };
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
-  }, [copySelectedNodes, pasteNodes]);
-
-  const [contextMenu, setContextMenu] = useState<{
-    targetEdgeIds: string[];
-    // 対象が全て同じ種類なら表示, 混在の場合は null
-    currentPathType: EdgePathType | null;
-    x: number;
-    y: number;
-  } | null>(null);
-
-  const CONTEXT_MENU_WIDTH = 160;
-  const CONTEXT_MENU_HEIGHT = 185; // header + 4 items の概算
-
-  const onEdgeContextMenu = useCallback(
-    (e: React.MouseEvent, edge: Edge) => {
-      e.preventDefault();
-      const currentEdges = getEdges();
-      // 右クリックした edge が選択中なら選択中の全 edge を対象にする
-      const targets = edge.selected
-        ? currentEdges.filter((ed) => ed.selected)
-        : [edge];
-      const targetEdgeIds = targets.map((ed) => ed.id);
-
-      // 対象エッジの pathType が全て一致するか確認
-      const types = targets.map(
-        (ed) => (ed.data?.pathType as EdgePathType | undefined) ?? 'bezier',
-      );
-      const currentPathType = types.every((t) => t === types[0])
-        ? types[0]
-        : null;
-
-      // 画面端からはみ出さないよう位置を補正
-      const x = Math.min(e.clientX, window.innerWidth - CONTEXT_MENU_WIDTH - 8);
-      const y = Math.min(
-        e.clientY,
-        window.innerHeight - CONTEXT_MENU_HEIGHT - 8,
-      );
-      setContextMenu({ targetEdgeIds, currentPathType, x, y });
-    },
-    [getEdges],
-  );
-
-  const setEdgePathType = useCallback(
-    (targetEdgeIds: string[], pathType: EdgePathType) => {
-      const targetSet = new Set(targetEdgeIds);
-      setEdges((es) =>
-        es.map((e) =>
-          targetSet.has(e.id) ? { ...e, data: { ...e.data, pathType } } : e,
-        ),
-      );
-      setContextMenu(null);
-    },
-    [setEdges],
-  );
-
-  // コンテキストメニュー外クリック / ESC で閉じる
-  useEffect(() => {
-    if (!contextMenu) return;
-    const onMouseDown = () => setContextMenu(null);
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setContextMenu(null);
-    };
-    window.addEventListener('mousedown', onMouseDown);
-    window.addEventListener('keydown', onKeyDown);
-    return () => {
-      window.removeEventListener('mousedown', onMouseDown);
-      window.removeEventListener('keydown', onKeyDown);
-    };
-  }, [contextMenu]);
-
-  const lastPaneClickTime = useRef(0);
-  const lastPaneClickPos = useRef({ x: 0, y: 0 });
-
-  const onPaneClick = useCallback(
-    (e: React.MouseEvent) => {
-      const now = Date.now();
-      const dx = e.clientX - lastPaneClickPos.current.x;
-      const dy = e.clientY - lastPaneClickPos.current.y;
-      const isSameSpot =
-        Math.abs(dx) < DOUBLE_CLICK_THRESHOLD_PX &&
-        Math.abs(dy) < DOUBLE_CLICK_THRESHOLD_PX;
-      if (
-        now - lastPaneClickTime.current < DOUBLE_CLICK_INTERVAL_MS &&
-        isSameSpot
-      ) {
-        const pos = screenToFlowPosition({ x: e.clientX, y: e.clientY });
-        addNode(pos);
-        lastPaneClickTime.current = 0;
-      } else {
-        lastPaneClickTime.current = now;
-        lastPaneClickPos.current = { x: e.clientX, y: e.clientY };
-      }
-    },
-    [screenToFlowPosition, addNode],
-  );
+  // --- Custom hooks ---
+  const { groupSelectedNodes } = useGroupNodes(setNodes);
+  // Cmd+C / Cmd+V のキーボード登録は useClipboard 内で行われる
+  useClipboard(getNodes, getEdges, setNodes, setEdges);
+  const { contextMenu, onEdgeContextMenu, setEdgePathType } =
+    useEdgeContextMenu(getEdges, setEdges);
+  const { onPaneClick } = usePaneDoubleClick(screenToFlowPosition, addNode);
 
   return (
     <div style={{ width: '100%', height: '100%' }}>

--- a/src/client/src/graphTransform.ts
+++ b/src/client/src/graphTransform.ts
@@ -15,8 +15,8 @@ export function toFlowNodes(nodes: GraphNode[]): Node[] {
   return nodes.map((n) => ({
     id: n.id,
     position: {
-      x: typeof n.style?.x === 'number' ? n.style.x : 0,
-      y: typeof n.style?.y === 'number' ? n.style.y : 0,
+      x: n.style?.x ?? 0,
+      y: n.style?.y ?? 0,
     },
     data: { label: n.content },
     type: n.style?.nodeType === 'group' ? 'groupNode' : 'editableNode',

--- a/src/client/src/hooks/useClipboard.ts
+++ b/src/client/src/hooks/useClipboard.ts
@@ -1,0 +1,56 @@
+import type { Edge, Node } from '@xyflow/react';
+import type { Dispatch, SetStateAction } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
+import { buildPastedData, collectCopyData } from '../graphTransform';
+
+const PASTE_OFFSET_PX = 20;
+
+export function useClipboard(
+  getNodes: () => Node[],
+  getEdges: () => Edge[],
+  setNodes: Dispatch<SetStateAction<Node[]>>,
+  setEdges: Dispatch<SetStateAction<Edge[]>>,
+): { copySelectedNodes: () => void; pasteNodes: () => void } {
+  const clipboard = useRef<{ nodes: Node[]; edges: Edge[] } | null>(null);
+
+  const copySelectedNodes = useCallback(() => {
+    const copied = collectCopyData(getNodes(), getEdges());
+    if (copied.nodes.length > 0) clipboard.current = copied;
+  }, [getNodes, getEdges]);
+
+  const pasteNodes = useCallback(() => {
+    if (!clipboard.current) return;
+    const { nodes: newNodes, edges: newEdges } = buildPastedData(
+      clipboard.current,
+      PASTE_OFFSET_PX,
+    );
+    setNodes((ns) => [
+      ...ns.map((n) => ({ ...n, selected: false })),
+      ...newNodes,
+    ]);
+    setEdges((es) => [...es, ...newEdges]);
+    // 次の貼り付けがさらにオフセットされるようクリップボードを更新
+    clipboard.current = { nodes: newNodes, edges: newEdges };
+  }, [setNodes, setEdges]);
+
+  // Cmd+C / Ctrl+C でコピー, Cmd+V / Ctrl+V でペースト
+  // INPUT / TEXTAREA 編集中は標準のクリップボード操作を妨げない
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey)) return;
+      const tag = (e.target as HTMLElement)?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+      if (e.key === 'c') {
+        e.preventDefault();
+        copySelectedNodes();
+      } else if (e.key === 'v') {
+        e.preventDefault();
+        pasteNodes();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [copySelectedNodes, pasteNodes]);
+
+  return { copySelectedNodes, pasteNodes };
+}

--- a/src/client/src/hooks/useEdgeContextMenu.ts
+++ b/src/client/src/hooks/useEdgeContextMenu.ts
@@ -1,0 +1,85 @@
+import type { EdgePathType } from '@conversensus/shared';
+import type { Edge } from '@xyflow/react';
+import type { Dispatch, MouseEvent, SetStateAction } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+
+const CONTEXT_MENU_WIDTH = 160;
+const CONTEXT_MENU_HEIGHT = 185; // header + 4 items の概算
+
+export type EdgeContextMenuState = {
+  targetEdgeIds: string[];
+  // 対象が全て同じ種類なら表示, 混在の場合は null
+  currentPathType: EdgePathType | null;
+  x: number;
+  y: number;
+} | null;
+
+export function useEdgeContextMenu(
+  getEdges: () => Edge[],
+  setEdges: Dispatch<SetStateAction<Edge[]>>,
+): {
+  contextMenu: EdgeContextMenuState;
+  onEdgeContextMenu: (e: MouseEvent, edge: Edge) => void;
+  setEdgePathType: (targetEdgeIds: string[], pathType: EdgePathType) => void;
+} {
+  const [contextMenu, setContextMenu] = useState<EdgeContextMenuState>(null);
+
+  const onEdgeContextMenu = useCallback(
+    (e: MouseEvent, edge: Edge) => {
+      e.preventDefault();
+      const currentEdges = getEdges();
+      // 右クリックした edge が選択中なら選択中の全 edge を対象にする
+      const targets = edge.selected
+        ? currentEdges.filter((ed) => ed.selected)
+        : [edge];
+      const targetEdgeIds = targets.map((ed) => ed.id);
+
+      // 対象エッジの pathType が全て一致するか確認
+      const types = targets.map(
+        (ed) => (ed.data?.pathType as EdgePathType | undefined) ?? 'bezier',
+      );
+      const currentPathType = types.every((t) => t === types[0])
+        ? types[0]
+        : null;
+
+      // 画面端からはみ出さないよう位置を補正
+      const x = Math.min(e.clientX, window.innerWidth - CONTEXT_MENU_WIDTH - 8);
+      const y = Math.min(
+        e.clientY,
+        window.innerHeight - CONTEXT_MENU_HEIGHT - 8,
+      );
+      setContextMenu({ targetEdgeIds, currentPathType, x, y });
+    },
+    [getEdges],
+  );
+
+  const setEdgePathType = useCallback(
+    (targetEdgeIds: string[], pathType: EdgePathType) => {
+      const targetSet = new Set(targetEdgeIds);
+      setEdges((es) =>
+        es.map((e) =>
+          targetSet.has(e.id) ? { ...e, data: { ...e.data, pathType } } : e,
+        ),
+      );
+      setContextMenu(null);
+    },
+    [setEdges],
+  );
+
+  // コンテキストメニュー外クリック / ESC で閉じる
+  useEffect(() => {
+    if (!contextMenu) return;
+    const onMouseDown = () => setContextMenu(null);
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setContextMenu(null);
+    };
+    window.addEventListener('mousedown', onMouseDown);
+    window.addEventListener('keydown', onKeyDown);
+    return () => {
+      window.removeEventListener('mousedown', onMouseDown);
+      window.removeEventListener('keydown', onKeyDown);
+    };
+  }, [contextMenu]);
+
+  return { contextMenu, onEdgeContextMenu, setEdgePathType };
+}

--- a/src/client/src/hooks/useGroupNodes.ts
+++ b/src/client/src/hooks/useGroupNodes.ts
@@ -1,0 +1,108 @@
+import type { Node } from '@xyflow/react';
+import type { Dispatch, SetStateAction } from 'react';
+import { useCallback, useEffect } from 'react';
+import {
+  DEFAULT_NODE_STYLE,
+  GROUP_PADDING,
+  GROUP_TITLE_HEIGHT,
+} from '../graphTransform';
+
+export function useGroupNodes(setNodes: Dispatch<SetStateAction<Node[]>>): {
+  groupSelectedNodes: () => void;
+} {
+  const groupSelectedNodes = useCallback(() => {
+    setNodes((ns) => {
+      const selected = ns.filter((n) => n.selected);
+      if (selected.length < 1) return ns;
+
+      // 選択ノードが同じ親を持つ場合, その親の中にグループを作る
+      const sharedParentId = selected.every(
+        (n) => n.parentId === selected[0].parentId,
+      )
+        ? selected[0].parentId
+        : undefined;
+
+      // 選択ノードのバウンディングボックスを計算
+      const minX = Math.min(...selected.map((n) => n.position.x));
+      const minY = Math.min(...selected.map((n) => n.position.y));
+      const maxX = Math.max(
+        ...selected.map(
+          (n) =>
+            n.position.x +
+            Number(
+              n.measured?.width ?? n.style?.width ?? DEFAULT_NODE_STYLE.width,
+            ),
+        ),
+      );
+      const maxY = Math.max(
+        ...selected.map(
+          (n) =>
+            n.position.y +
+            Number(
+              n.measured?.height ??
+                n.style?.height ??
+                DEFAULT_NODE_STYLE.height,
+            ),
+        ),
+      );
+
+      const parentX = minX - GROUP_PADDING;
+      const parentY = minY - GROUP_PADDING - GROUP_TITLE_HEIGHT;
+      const parentWidth = maxX - minX + GROUP_PADDING * 2;
+      const parentHeight = maxY - minY + GROUP_PADDING * 2 + GROUP_TITLE_HEIGHT;
+      const parentId = crypto.randomUUID();
+
+      const parentNode = {
+        id: parentId,
+        position: { x: parentX, y: parentY },
+        data: { label: 'グループ' },
+        type: 'groupNode' as const,
+        parentId: sharedParentId,
+        style: { width: parentWidth, height: parentHeight, nodeType: 'group' },
+      };
+
+      const selectedIds = new Set(selected.map((n) => n.id));
+
+      const mappedNodes = ns.map((n) => {
+        if (!selectedIds.has(n.id)) return n;
+        return {
+          ...n,
+          parentId,
+          selected: false,
+          position: {
+            x: n.position.x - parentX,
+            y: n.position.y - parentY,
+          },
+        };
+      });
+
+      // React Flow では親ノードを子ノードより前に配置する必要がある
+      // ネスト時は sharedParentId の直後に挿入する
+      if (sharedParentId) {
+        const idx = mappedNodes.findIndex((n) => n.id === sharedParentId);
+        const insertAt = idx >= 0 ? idx + 1 : 0;
+        return [
+          ...mappedNodes.slice(0, insertAt),
+          parentNode,
+          ...mappedNodes.slice(insertAt),
+        ];
+      }
+
+      return [parentNode, ...mappedNodes];
+    });
+  }, [setNodes]);
+
+  // Cmd+G / Ctrl+G でグループ化
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'g') {
+        e.preventDefault();
+        groupSelectedNodes();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [groupSelectedNodes]);
+
+  return { groupSelectedNodes };
+}

--- a/src/client/src/hooks/usePaneDoubleClick.ts
+++ b/src/client/src/hooks/usePaneDoubleClick.ts
@@ -1,0 +1,41 @@
+import type { MouseEvent } from 'react';
+import { useCallback, useRef } from 'react';
+
+const DOUBLE_CLICK_INTERVAL_MS = 300;
+const DOUBLE_CLICK_THRESHOLD_PX = 5;
+
+export function usePaneDoubleClick(
+  screenToFlowPosition: (pos: { x: number; y: number }) => {
+    x: number;
+    y: number;
+  },
+  addNode: (position?: { x: number; y: number }) => void,
+): { onPaneClick: (e: MouseEvent) => void } {
+  const lastPaneClickTime = useRef(0);
+  const lastPaneClickPos = useRef({ x: 0, y: 0 });
+
+  const onPaneClick = useCallback(
+    (e: MouseEvent) => {
+      const now = Date.now();
+      const dx = e.clientX - lastPaneClickPos.current.x;
+      const dy = e.clientY - lastPaneClickPos.current.y;
+      const isSameSpot =
+        Math.abs(dx) < DOUBLE_CLICK_THRESHOLD_PX &&
+        Math.abs(dy) < DOUBLE_CLICK_THRESHOLD_PX;
+      if (
+        now - lastPaneClickTime.current < DOUBLE_CLICK_INTERVAL_MS &&
+        isSameSpot
+      ) {
+        const pos = screenToFlowPosition({ x: e.clientX, y: e.clientY });
+        addNode(pos);
+        lastPaneClickTime.current = 0;
+      } else {
+        lastPaneClickTime.current = now;
+        lastPaneClickPos.current = { x: e.clientX, y: e.clientY };
+      }
+    },
+    [screenToFlowPosition, addNode],
+  );
+
+  return { onPaneClick };
+}

--- a/src/shared/src/index.ts
+++ b/src/shared/src/index.ts
@@ -23,12 +23,25 @@ export type SheetName = string;
 export const StyleSchema = z.record(z.string(), z.unknown());
 export type Style = z.infer<typeof StyleSchema>;
 
+// ノードの永続化スタイル: 座標・サイズ・種別を型安全に定義
+// catchall で未知フィールドを保持し前方互換性を確保する
+export const NodeStyleSchema = z
+  .object({
+    x: z.number().optional(),
+    y: z.number().optional(),
+    width: z.union([z.number(), z.string()]).optional(),
+    height: z.union([z.number(), z.string()]).optional(),
+    nodeType: z.literal('group').optional(),
+  })
+  .catchall(z.unknown());
+export type NodeStyle = z.infer<typeof NodeStyleSchema>;
+
 // --- Domain schemas ---
 export const GraphNodeSchema = z.object({
   id: NodeIdSchema,
   content: z.string(),
   parentId: NodeIdSchema.optional(),
-  style: StyleSchema.optional(),
+  style: NodeStyleSchema.optional(),
 });
 
 export const EdgePathTypeSchema = z.enum([


### PR DESCRIPTION
## Summary

- `GraphEditor.tsx` を ~500行 → ~200行に削減（4つのカスタムフックを抽出）
  - `useGroupNodes`: グループ化ロジック + Cmd+G ショートカット
  - `useClipboard`: コピー/ペーストロジック + Cmd+C/V ショートカット
  - `useEdgeContextMenu`: エッジ右クリックメニューの状態管理
  - `usePaneDoubleClick`: ダブルクリックによるノード追加
- `NodeStyleSchema` を `z.record` から型付きスキーマに変更（`.catchall(z.unknown())` で前方互換性を維持）

## Test plan

- [x] 既存の47テストがすべてパスすること
- [x] グループ化（Cmd+G）が正常に動作すること
- [x] コピー/ペースト（Cmd+C/V）が正常に動作すること
- [x] エッジ右クリックメニューが正常に動作すること
- [x] ペインダブルクリックでノード追加が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)