### PR TITLE
refactor: useInlineEdit フック抽出 + EdgeContextMenu コンポーネント分離

### DIFF
--- a/src/client/src/EdgeContextMenu.tsx
+++ b/src/client/src/EdgeContextMenu.tsx
@@ -1,0 +1,77 @@
+import type { EdgePathType } from '@conversensus/shared';
+import type { EdgeContextMenuState } from './hooks/useEdgeContextMenu';
+
+type Props = {
+  contextMenu: NonNullable<EdgeContextMenuState>;
+  onSelect: (targetEdgeIds: string[], pathType: EdgePathType) => void;
+};
+
+export function EdgeContextMenu({ contextMenu, onSelect }: Props) {
+  return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: context menu uses mousedown to block propagation
+    <div
+      style={{
+        position: 'fixed',
+        top: contextMenu.y,
+        left: contextMenu.x,
+        background: '#fff',
+        border: '1px solid #ddd',
+        borderRadius: 6,
+        boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
+        zIndex: 1000,
+        minWidth: 160,
+        padding: '4px 0',
+      }}
+      onMouseDown={(e) => e.stopPropagation()}
+    >
+      <div
+        style={{
+          padding: '4px 14px 6px',
+          fontSize: 11,
+          color: '#888',
+          borderBottom: '1px solid #eee',
+          marginBottom: 4,
+        }}
+      >
+        {contextMenu.targetEdgeIds.length === 1
+          ? 'エッジの種類'
+          : `${contextMenu.targetEdgeIds.length} 本のエッジを変更`}
+      </div>
+      {(
+        [
+          ['bezier', 'Bezier（曲線）'],
+          ['straight', 'Straight（直線）'],
+          ['step', 'Step（直角）'],
+          ['smoothstep', 'Smooth Step（角丸）'],
+        ] as [EdgePathType, string][]
+      ).map(([type, label]) => {
+        const isCurrent = contextMenu.currentPathType === type;
+        return (
+          <button
+            key={type}
+            type="button"
+            onClick={() => onSelect(contextMenu.targetEdgeIds, type)}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
+              width: '100%',
+              padding: '6px 14px',
+              textAlign: 'left',
+              background: 'none',
+              border: 'none',
+              fontSize: 13,
+              fontWeight: isCurrent ? 'bold' : 'normal',
+              cursor: 'pointer',
+            }}
+          >
+            <span style={{ width: 12, flexShrink: 0 }}>
+              {isCurrent ? '✓' : ''}
+            </span>
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/client/src/EditableLabelEdge.tsx
+++ b/src/client/src/EditableLabelEdge.tsx
@@ -8,7 +8,7 @@ import {
   getStraightPath,
   useReactFlow,
 } from '@xyflow/react';
-import { useCallback, useState } from 'react';
+import { useInlineEdit } from './hooks/useInlineEdit';
 
 function getEdgePath(
   pathType: EdgePathType,
@@ -47,9 +47,6 @@ export function EditableLabelEdge({
   data,
 }: EdgeProps) {
   const { setEdges } = useReactFlow();
-  const [editing, setEditing] = useState(false);
-  const [inputValue, setInputValue] = useState('');
-  const [composing, setComposing] = useState(false);
 
   const pathType = (data?.pathType as EdgePathType | undefined) ?? 'bezier';
   const [edgePath, labelX, labelY] = getEdgePath(pathType, {
@@ -61,22 +58,18 @@ export function EditableLabelEdge({
     targetPosition,
   });
 
-  const startEdit = useCallback(() => {
-    setInputValue(String(label ?? ''));
-    setEditing(true);
-  }, [label]);
-
-  const confirm = useCallback(() => {
-    setEdges((es) =>
-      es.map((e) => (e.id === id ? { ...e, label: inputValue } : e)),
-    );
-    setEditing(false);
-  }, [id, inputValue, setEdges]);
-
-  const cancel = useCallback(() => {
-    setInputValue(String(label ?? ''));
-    setEditing(false);
-  }, [label]);
+  const {
+    editing,
+    inputValue,
+    setInputValue,
+    composing,
+    setComposing,
+    startEdit,
+    confirm,
+    cancel,
+  } = useInlineEdit(String(label ?? ''), (value) =>
+    setEdges((es) => es.map((e) => (e.id === id ? { ...e, label: value } : e))),
+  );
 
   return (
     <>

--- a/src/client/src/EditableNode.tsx
+++ b/src/client/src/EditableNode.tsx
@@ -5,10 +5,11 @@ import {
   Position,
   useReactFlow,
 } from '@xyflow/react';
-import { useCallback, useRef, useState } from 'react';
+import { useCallback } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { recalculateParentBounds } from './graphTransform';
+import { useInlineEdit } from './hooks/useInlineEdit';
 
 export function EditableNode({ id, data, selected }: NodeProps) {
   const { setNodes } = useReactFlow();
@@ -16,37 +17,17 @@ export function EditableNode({ id, data, selected }: NodeProps) {
     () => setNodes((ns) => recalculateParentBounds(ns)),
     [setNodes],
   );
-  const [editing, setEditing] = useState(false);
-  const [inputValue, setInputValue] = useState('');
-  // Escape 後の onBlur で confirm が呼ばれないようにするフラグ
-  const cancelledRef = useRef(false);
 
   const label = String(data.label ?? '');
 
-  const startEdit = useCallback(() => {
-    cancelledRef.current = false;
-    setInputValue(label);
-    setEditing(true);
-  }, [label]);
-
-  const confirm = useCallback(() => {
-    if (cancelledRef.current) {
-      cancelledRef.current = false;
-      return;
-    }
-    setNodes((ns) =>
-      ns.map((n) =>
-        n.id === id ? { ...n, data: { ...n.data, label: inputValue } } : n,
+  const { editing, inputValue, setInputValue, startEdit, confirm, cancel } =
+    useInlineEdit(label, (value) =>
+      setNodes((ns) =>
+        ns.map((n) =>
+          n.id === id ? { ...n, data: { ...n.data, label: value } } : n,
+        ),
       ),
     );
-    setEditing(false);
-  }, [id, inputValue, setNodes]);
-
-  const cancel = useCallback(() => {
-    cancelledRef.current = true;
-    setInputValue(label);
-    setEditing(false);
-  }, [label]);
 
   return (
     <>

--- a/src/client/src/GraphEditor.tsx
+++ b/src/client/src/GraphEditor.tsx
@@ -18,7 +18,8 @@ import {
 } from '@xyflow/react';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import '@xyflow/react/dist/style.css';
-import type { EdgePathType, GraphFile } from '@conversensus/shared';
+import type { GraphFile } from '@conversensus/shared';
+import { EdgeContextMenu } from './EdgeContextMenu';
 import { EditableLabelEdge } from './EditableLabelEdge';
 import { EditableNode } from './EditableNode';
 import { GroupNode } from './GroupNode';
@@ -200,71 +201,7 @@ function GraphEditorInner({ file, onChange }: Props) {
         </Panel>
       </ReactFlow>
       {contextMenu && (
-        // biome-ignore lint/a11y/noStaticElementInteractions: context menu uses mousedown to block propagation
-        <div
-          style={{
-            position: 'fixed',
-            top: contextMenu.y,
-            left: contextMenu.x,
-            background: '#fff',
-            border: '1px solid #ddd',
-            borderRadius: 6,
-            boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
-            zIndex: 1000,
-            minWidth: 160,
-            padding: '4px 0',
-          }}
-          onMouseDown={(e) => e.stopPropagation()}
-        >
-          <div
-            style={{
-              padding: '4px 14px 6px',
-              fontSize: 11,
-              color: '#888',
-              borderBottom: '1px solid #eee',
-              marginBottom: 4,
-            }}
-          >
-            {contextMenu.targetEdgeIds.length === 1
-              ? 'エッジの種類'
-              : `${contextMenu.targetEdgeIds.length} 本のエッジを変更`}
-          </div>
-          {(
-            [
-              ['bezier', 'Bezier（曲線）'],
-              ['straight', 'Straight（直線）'],
-              ['step', 'Step（直角）'],
-              ['smoothstep', 'Smooth Step（角丸）'],
-            ] as [EdgePathType, string][]
-          ).map(([type, label]) => {
-            const isCurrent = contextMenu.currentPathType === type;
-            return (
-              <button
-                key={type}
-                type="button"
-                onClick={() => setEdgePathType(contextMenu.targetEdgeIds, type)}
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 6,
-                  width: '100%',
-                  padding: '6px 14px',
-                  textAlign: 'left',
-                  background: 'none',
-                  border: 'none',
-                  fontSize: 13,
-                  fontWeight: isCurrent ? 'bold' : 'normal',
-                  cursor: 'pointer',
-                }}
-              >
-                <span style={{ width: 12, flexShrink: 0 }}>
-                  {isCurrent ? '✓' : ''}
-                </span>
-                {label}
-              </button>
-            );
-          })}
-        </div>
+        <EdgeContextMenu contextMenu={contextMenu} onSelect={setEdgePathType} />
       )}
     </div>
   );

--- a/src/client/src/GroupNode.tsx
+++ b/src/client/src/GroupNode.tsx
@@ -5,8 +5,9 @@ import {
   Position,
   useReactFlow,
 } from '@xyflow/react';
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useRef } from 'react';
 import { DEFAULT_NODE_STYLE, recalculateParentBounds } from './graphTransform';
+import { useInlineEdit } from './hooks/useInlineEdit';
 
 export function GroupNode({
   id,
@@ -49,37 +50,24 @@ export function GroupNode({
     },
     [id, screenToFlowPosition, setNodes],
   );
-  const [editing, setEditing] = useState(false);
-  const [inputValue, setInputValue] = useState('');
-  const [composing, setComposing] = useState(false);
-  const cancelledRef = useRef(false);
-
   const label = String(data.label ?? '');
 
-  const startEdit = useCallback(() => {
-    cancelledRef.current = false;
-    setInputValue(label);
-    setEditing(true);
-  }, [label]);
-
-  const confirm = useCallback(() => {
-    if (cancelledRef.current) {
-      cancelledRef.current = false;
-      return;
-    }
+  const {
+    editing,
+    inputValue,
+    setInputValue,
+    composing,
+    setComposing,
+    startEdit,
+    confirm,
+    cancel,
+  } = useInlineEdit(label, (value) =>
     setNodes((ns) =>
       ns.map((n) =>
-        n.id === id ? { ...n, data: { ...n.data, label: inputValue } } : n,
+        n.id === id ? { ...n, data: { ...n.data, label: value } } : n,
       ),
-    );
-    setEditing(false);
-  }, [id, inputValue, setNodes]);
-
-  const cancel = useCallback(() => {
-    cancelledRef.current = true;
-    setInputValue(label);
-    setEditing(false);
-  }, [label]);
+    ),
+  );
 
   return (
     <>

--- a/src/client/src/hooks/useInlineEdit.ts
+++ b/src/client/src/hooks/useInlineEdit.ts
@@ -1,0 +1,48 @@
+import { useCallback, useRef, useState } from 'react';
+
+/**
+ * インラインテキスト編集の共通ロジック
+ * EditableNode / GroupNode / EditableLabelEdge で共有する
+ */
+export function useInlineEdit(
+  initialValue: string,
+  onConfirm: (value: string) => void,
+) {
+  const [editing, setEditing] = useState(false);
+  const [inputValue, setInputValue] = useState('');
+  const [composing, setComposing] = useState(false);
+  // Escape 後の onBlur で confirm が呼ばれないようにするフラグ
+  const cancelledRef = useRef(false);
+
+  const startEdit = useCallback(() => {
+    cancelledRef.current = false;
+    setInputValue(initialValue);
+    setEditing(true);
+  }, [initialValue]);
+
+  const confirm = useCallback(() => {
+    if (cancelledRef.current) {
+      cancelledRef.current = false;
+      return;
+    }
+    onConfirm(inputValue);
+    setEditing(false);
+  }, [inputValue, onConfirm]);
+
+  const cancel = useCallback(() => {
+    cancelledRef.current = true;
+    setInputValue(initialValue);
+    setEditing(false);
+  }, [initialValue]);
+
+  return {
+    editing,
+    inputValue,
+    setInputValue,
+    composing,
+    setComposing,
+    startEdit,
+    confirm,
+    cancel,
+  };
+}


### PR DESCRIPTION
## Summary

- `useInlineEdit` フックを新規作成し3コンポーネントの重複ロジックを一元化
  - `EditableNode` / `GroupNode` / `EditableLabelEdge` で共通していた `editing`, `inputValue`, `composing`, `cancelledRef`, `startEdit`, `confirm`, `cancel` を集約
- `EdgeContextMenu` を `GraphEditor.tsx` から独立コンポーネントとして抽出
  - `GraphEditor.tsx` がさらにスリムに

## Test plan

- [x] 63テストがすべてパスすること
- [x] ノード編集（ダブルクリック→テキスト入力→Enter/ESC/blur）が正常に動作すること
- [x] グループ名編集（ダブルクリック→IME入力→Enter/ESC/blur）が正常に動作すること
- [x] エッジラベル編集（ダブルクリック→Enter/ESC/blur）が正常に動作すること
- [x] エッジ右クリックメニューが正常に表示・選択できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)