### PR TITLE
feat(atproto): PDS ポーリングによるリモート変更検出

### DIFF
--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -15,7 +15,14 @@ import {
   removeFile,
   saveFile,
 } from './api';
-import { login, syncFileToAtproto } from './atproto';
+import {
+  initCidCacheFromPds,
+  login,
+  type RemoteChange,
+  startPolling,
+  stopPolling,
+  syncFileToAtproto,
+} from './atproto';
 import { GraphEditor } from './GraphEditor';
 import type { PopupTarget } from './SettingsPopup';
 import { Sidebar } from './Sidebar';
@@ -49,11 +56,25 @@ export default function App() {
   );
   const [newFileName, setNewFileName] = useState('');
   const [popupTarget, setPopupTarget] = useState<PopupTarget | null>(null);
+  // リモート変更検出: ポーリングで検出された他ユーザーの変更を保持 (#59 でコンフリクト UI に利用)
+  const [_remoteChanges, setRemoteChanges] = useState<RemoteChange[]>([]);
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     fetchFiles().then(setFiles).catch(console.error);
-    tryAtprotoAutoLogin();
+    // ATProto: ログイン後に CID キャッシュを初期化してポーリング開始
+    tryAtprotoAutoLogin().then(async () => {
+      try {
+        await initCidCacheFromPds();
+        startPolling((changes) => {
+          console.info('[atproto] remote changes detected:', changes);
+          setRemoteChanges((prev) => [...prev, ...changes]);
+        });
+      } catch {
+        // ATProto 未設定時はサイレントにスキップ
+      }
+    });
+    return () => stopPolling();
   }, []);
 
   useEffect(() => {

--- a/src/client/src/atproto/cidCache.ts
+++ b/src/client/src/atproto/cidCache.ts
@@ -1,0 +1,33 @@
+/**
+ * CID キャッシュ: PDS 上の各レコードの最終確認済み CID を追跡する。
+ * - 書き込み時 (syncSheetToAtproto) → setCid で更新
+ * - ログイン時 (initCidCacheFromPds) → PDS の現在状態で初期化
+ * - ポーリング時 (poller.ts) → 新 CID と比較してリモート変更を検出
+ */
+
+const _cache = new Map<string, string>(); // `${collection}/${rkey}` → cid
+
+function key(collection: string, rkey: string): string {
+  return `${collection}/${rkey}`;
+}
+
+export function setCid(collection: string, rkey: string, cid: string): void {
+  _cache.set(key(collection, rkey), cid);
+}
+
+export function getCid(collection: string, rkey: string): string | undefined {
+  return _cache.get(key(collection, rkey));
+}
+
+/** AT-URI から collection / rkey を取り出して setCid する */
+export function cacheResult(uri: string, cid: string): void {
+  // AT-URI: "at://did/collection/rkey"
+  const parts = uri.split('/');
+  const collection = parts[3];
+  const rkey = parts[4];
+  if (collection && rkey) setCid(collection, rkey, cid);
+}
+
+export function clearCache(): void {
+  _cache.clear();
+}

--- a/src/client/src/atproto/index.ts
+++ b/src/client/src/atproto/index.ts
@@ -9,6 +9,12 @@ export {
   sheets,
 } from './collections';
 export {
+  initCidCacheFromPds,
+  POLL_INTERVAL_MS,
+  startPolling,
+  stopPolling,
+} from './poller';
+export {
   fetchSheetsFromAtproto,
   syncFileToAtproto,
   syncSheetToAtproto,
@@ -19,6 +25,7 @@ export type {
   NodeLayoutRecord,
   NodeRecord,
   RecordResult,
+  RemoteChange,
   SheetRecord,
   StrongRef,
 } from './types';

--- a/src/client/src/atproto/poller.ts
+++ b/src/client/src/atproto/poller.ts
@@ -1,0 +1,95 @@
+/**
+ * ATProto PDS ポーリングによるリモート変更検出
+ *
+ * 検出ロジック:
+ *   1. ログイン後に initCidCacheFromPds() で PDS の現在状態をキャッシュ
+ *   2. startPolling() でインターバル毎に全コレクションをスキャン
+ *   3. キャッシュ済み CID と異なるレコードを RemoteChange として報告
+ *
+ * 注意: 新規レコード (キャッシュに未登録) はコンフリクト検出の対象外。
+ * 既存レコードへの同時変更のみを検出する。
+ */
+
+import { cacheResult, getCid, setCid } from './cidCache';
+import { edgeLayouts, edges, nodeLayouts, nodes, sheets } from './collections';
+import { NSID, type RemoteChange } from './types';
+
+export type { RemoteChange };
+
+// collection NSID → list 関数のマッピング (pagination 込み)
+const COLLECTION_LISTS: Array<
+  [string, () => Promise<Array<{ uri: string; cid: string; value: unknown }>>]
+> = [
+  [NSID.sheet, () => sheets.list()],
+  [NSID.node, () => nodes.list()],
+  [NSID.edge, () => edges.list()],
+  [NSID.nodeLayout, () => nodeLayouts.list()],
+  [NSID.edgeLayout, () => edgeLayouts.list()],
+];
+
+function rkeyFromUri(uri: string): string {
+  return uri.split('/').at(-1) ?? uri;
+}
+
+/**
+ * ログイン後に呼び出す。PDS の現在状態で CID キャッシュを初期化する。
+ * 以降のポーリングはこの状態を baseline として差分を検出する。
+ */
+export async function initCidCacheFromPds(): Promise<void> {
+  await Promise.all(
+    COLLECTION_LISTS.map(async ([collection, list]) => {
+      const records = await list();
+      for (const r of records) {
+        setCid(collection, rkeyFromUri(r.uri), r.cid);
+      }
+    }),
+  );
+}
+
+/** キャッシュ済み CID と異なるレコードを収集して返す */
+async function detectChanges(): Promise<RemoteChange[]> {
+  const changes: RemoteChange[] = [];
+
+  await Promise.all(
+    COLLECTION_LISTS.map(async ([collection, list]) => {
+      const records = await list();
+      for (const r of records) {
+        const rkey = rkeyFromUri(r.uri);
+        const knownCid = getCid(collection, rkey);
+        if (knownCid !== undefined && knownCid !== r.cid) {
+          // キャッシュに存在するが CID が変わった → 他ユーザーによるリモート変更
+          changes.push({ collection, rkey, cid: r.cid, value: r.value });
+          cacheResult(r.uri, r.cid); // キャッシュを最新に更新
+        }
+      }
+    }),
+  );
+
+  return changes;
+}
+
+export const POLL_INTERVAL_MS = 10_000; // 10秒 (開発環境向け)
+
+let _timerId: ReturnType<typeof setInterval> | null = null;
+
+export function startPolling(
+  onChanges: (changes: RemoteChange[]) => void,
+  intervalMs = POLL_INTERVAL_MS,
+): void {
+  if (_timerId !== null) return; // 多重起動防止
+  _timerId = setInterval(async () => {
+    try {
+      const changes = await detectChanges();
+      if (changes.length > 0) onChanges(changes);
+    } catch (err) {
+      console.warn('[atproto] polling error:', err);
+    }
+  }, intervalMs);
+}
+
+export function stopPolling(): void {
+  if (_timerId !== null) {
+    clearInterval(_timerId);
+    _timerId = null;
+  }
+}

--- a/src/client/src/atproto/sync.ts
+++ b/src/client/src/atproto/sync.ts
@@ -10,6 +10,7 @@
  */
 
 import type { EdgeId, GraphFile, NodeId, Sheet } from '@conversensus/shared';
+import { cacheResult } from './cidCache';
 import {
   edgeLayouts,
   edges,
@@ -51,6 +52,7 @@ export async function syncSheetToAtproto(sheet: Sheet): Promise<void> {
 
   // 1. sheet レコードを put → sheetRef を取得
   const sheetResult = await sheets.put(sheet.id, sheetToRecord(sheet, now));
+  cacheResult(sheetResult.uri, sheetResult.cid);
   const sheetRef: StrongRef = { uri: sheetResult.uri, cid: sheetResult.cid };
 
   // 2. 全 node を put (並列) → nodeId → StrongRef マップを構築
@@ -61,6 +63,7 @@ export async function syncSheetToAtproto(sheet: Sheet): Promise<void> {
         node.id,
         nodeToRecord(node, sheetRef, now),
       );
+      cacheResult(result.uri, result.cid);
       nodeRefs.set(node.id, { uri: result.uri, cid: result.cid });
     }),
   );
@@ -81,6 +84,7 @@ export async function syncSheetToAtproto(sheet: Sheet): Promise<void> {
         edge.id,
         edgeToRecord(edge, sheetRef, sourceRef, targetRef, now),
       );
+      cacheResult(result.uri, result.cid);
       edgeRefs.set(edge.id, { uri: result.uri, cid: result.cid });
     }),
   );
@@ -94,10 +98,11 @@ export async function syncSheetToAtproto(sheet: Sheet): Promise<void> {
         const parentRef = layout.parentId
           ? nodeRefs.get(layout.parentId)
           : undefined;
-        await nodeLayouts.put(
+        const r = await nodeLayouts.put(
           layout.nodeId,
           nodeLayoutToRecord(layout, nodeRef, parentRef, now),
         );
+        cacheResult(r.uri, r.cid);
       }),
     );
   }
@@ -108,10 +113,11 @@ export async function syncSheetToAtproto(sheet: Sheet): Promise<void> {
       sheet.edgeLayouts.map(async (layout) => {
         const edgeRef = edgeRefs.get(layout.edgeId);
         if (!edgeRef) return;
-        await edgeLayouts.put(
+        const r = await edgeLayouts.put(
           layout.edgeId,
           edgeLayoutToRecord(layout, edgeRef, now),
         );
+        cacheResult(r.uri, r.cid);
       }),
     );
   }

--- a/src/client/src/atproto/types.ts
+++ b/src/client/src/atproto/types.ts
@@ -59,3 +59,11 @@ export type EdgeLayoutRecord = {
 };
 
 export type RecordResult = { uri: string; cid: string };
+
+/** ポーリングで検出されたリモート変更 */
+export type RemoteChange = {
+  collection: string; // NSID (例: "app.conversensus.graph.node")
+  rkey: string; // レコードキー (例: nodeId)
+  cid: string; // 新しい CID
+  value: unknown; // PDS 上の最新レコード値
+};


### PR DESCRIPTION
Closes #58

## Summary

- **cidCache.ts** (新規): CID キャッシュモジュール。書き込み時とポーリング時に共有し、自分が書いたレコードを誤検出しない
- **poller.ts** (新規): 全コレクションを定期スキャン (10秒) し、CID 差分でリモート変更を検出
  - `initCidCacheFromPds()`: ログイン後に PDS の現在状態でキャッシュ初期化 (PDS → ローカル読み込みフロー)
  - `startPolling()` / `stopPolling()`: ポーリングのライフサイクル管理
- **sync.ts**: `putRecord` 後に `cacheResult()` で CID を記録
- **App.tsx**: ログイン後に `initCidCacheFromPds` + `startPolling` を起動。検出した変更を `_remoteChanges` 状態に蓄積 (コンフリクト UI は #59 で実装)

## 検出ロジック

```
ログイン
  → initCidCacheFromPds() で PDS の全レコード CID をキャッシュ
  → startPolling() で 10秒毎にスキャン
      各レコードの CID を cache と比較
      cache[collection/rkey] ≠ PDS CID → RemoteChange として報告
      (cache に未登録の新規レコードはスキップ)
```

## 制約・既知の制限

- 新規レコード (キャッシュ未登録) は検出対象外 — 既存レコードへの同時変更のみ
- Firehose (`subscribeRepos`) は未実装、ポーリングのみ

## Test plan

- [x] PDS を起動し、2つのセッションで同じノードを編集 → 一方のコンソールに `[atproto] remote changes detected:` が出ることを確認
- [x] 自分が書いたレコードはポーリングで誤検出されないことを確認
- [x] `stopPolling()` でポーリングが停止することを確認 (アンマウント時)

🤖 Generated with [Claude Code](https://claude.com/claude-code)