### PR TITLE
feat(atproto): branch の merge / close / delete を実装する

### DIFF
--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -23,6 +23,8 @@ import {
   computeOperations,
   createBranch,
   createCommit,
+  createMergeRecord,
+  deleteBranchFromPds,
   fetchBranchesForSheet,
   fetchCommitsForBranch,
   fetchFileFromAtproto,
@@ -35,10 +37,13 @@ import {
   startPolling,
   stopPolling,
   syncFileToAtproto,
+  updateBranchStatus,
 } from './atproto';
+import { BranchDeleteDialog } from './BranchDeleteDialog';
 import { CommitDialog } from './CommitDialog';
 import { ConflictPanel } from './ConflictPanel';
 import { GraphEditor } from './GraphEditor';
+import { MergeDialog } from './MergeDialog';
 import type { PopupTarget } from './SettingsPopup';
 import { Sidebar } from './Sidebar';
 
@@ -82,6 +87,13 @@ export default function App() {
   );
   const [branchCommits, setBranchCommits] = useState<Commit[]>([]);
   const [commitDialogOpen, setCommitDialogOpen] = useState(false);
+  const [mergeDialogOpen, setMergeDialogOpen] = useState(false);
+  const [deleteBranchState, setDeleteBranchState] = useState<{
+    sheetId: SheetId;
+    branch: Branch;
+    commits: Commit[];
+    hasPendingChanges: boolean;
+  } | null>(null);
   // branch mode の base state (commit のたびに更新)
   const branchBaseSheet = useRef<Sheet | null>(null);
   // branchBaseSheet の更新を useMemo に伝えるためのカウンタ (ref は deps に入れられないため)
@@ -318,6 +330,110 @@ export default function App() {
     [activeBranch, activeSheetId, activeFile, pendingOps],
   );
 
+  const handleClose = useCallback(async () => {
+    if (!activeBranch || !activeSheetId) return;
+    try {
+      await updateBranchStatus(activeBranch, 'closed');
+      setSheetBranches((prev) => {
+        const next = new Map(prev);
+        const existing = next.get(activeSheetId) ?? [];
+        next.set(
+          activeSheetId,
+          existing.map((b) =>
+            b.id === activeBranch.id ? { ...b, status: 'closed' as const } : b,
+          ),
+        );
+        return next;
+      });
+      // trunk に戻る
+      setActiveBranch(null);
+      branchBaseSheet.current = null;
+      branchOriginalBase.current = null;
+      setBranchCommits([]);
+      if (preBranchFile.current) {
+        setActiveFile(preBranchFile.current);
+        preBranchFile.current = null;
+      }
+    } catch (err) {
+      console.warn('[close] failed:', err);
+      alert('クローズに失敗しました。');
+    }
+  }, [activeBranch, activeSheetId]);
+
+  const handleDeleteBranch = useCallback(
+    async (sheetId: SheetId, branch: Branch) => {
+      try {
+        const branchCommitsList = await fetchCommitsForBranch(branch.uri);
+
+        // 他の branch がこの branch の commit を参照していないか確認
+        const allBranchesForSheet = sheetBranches.get(sheetId) ?? [];
+        const branchCommitUris = new Set(branchCommitsList.map((c) => c.uri));
+        const hasDependents = allBranchesForSheet.some(
+          (b) =>
+            b.id !== branch.id &&
+            b.baseCommitUri &&
+            branchCommitUris.has(b.baseCommitUri),
+        );
+        if (hasDependents) {
+          alert(
+            'このブランチを参照している他のブランチがあるため, 削除できません。',
+          );
+          return;
+        }
+
+        const hasPendingChanges =
+          activeBranch?.id === branch.id && pendingOps.length > 0;
+
+        setDeleteBranchState({
+          sheetId,
+          branch,
+          commits: branchCommitsList,
+          hasPendingChanges,
+        });
+      } catch (err) {
+        console.warn('[delete branch] fetch commits failed:', err);
+        alert('branch の情報取得に失敗しました。');
+      }
+    },
+    [sheetBranches, activeBranch, pendingOps],
+  );
+
+  const handleConfirmDeleteBranch = useCallback(async () => {
+    if (!deleteBranchState) return;
+    const { sheetId, branch } = deleteBranchState;
+
+    try {
+      await deleteBranchFromPds(branch);
+
+      // active branch だった場合は trunk に戻す
+      if (activeBranch?.id === branch.id) {
+        setActiveBranch(null);
+        branchBaseSheet.current = null;
+        branchOriginalBase.current = null;
+        setBranchCommits([]);
+        if (preBranchFile.current) {
+          setActiveFile(preBranchFile.current);
+          preBranchFile.current = null;
+        }
+      }
+
+      setSheetBranches((prev) => {
+        const next = new Map(prev);
+        const existing = next.get(sheetId) ?? [];
+        next.set(
+          sheetId,
+          existing.filter((b) => b.id !== branch.id),
+        );
+        return next;
+      });
+
+      setDeleteBranchState(null);
+    } catch (err) {
+      console.warn('[delete branch] failed:', err);
+      alert('branch の削除に失敗しました。');
+    }
+  }, [deleteBranchState, activeBranch]);
+
   useEffect(() => {
     fetchFiles().then(setFiles).catch(console.error);
     // ATProto: ログイン後に CID キャッシュを初期化してポーリング開始
@@ -464,6 +580,52 @@ export default function App() {
       console.warn('[cache] local save failed:', err),
     );
   }, []);
+
+  const handleMerge = useCallback(async () => {
+    if (!activeBranch || !activeSheetId) return;
+    const trunkFile = preBranchFile.current;
+    const trunkSheet = trunkFile?.sheets.find((s) => s.id === activeSheetId);
+    if (!trunkSheet || !trunkFile) return;
+
+    const allOps = branchCommits.flatMap((c) => c.operations);
+    const mergedSheet = applyOperations(trunkSheet, allOps);
+    const mergedFile: GraphFile = {
+      ...trunkFile,
+      sheets: trunkFile.sheets.map((s) =>
+        s.id === activeSheetId ? mergedSheet : s,
+      ),
+    };
+
+    try {
+      await persistFile(mergedFile);
+      preBranchFile.current = mergedFile;
+
+      const sheetRef = await sheets.ref(activeSheetId);
+      const branchRef = { uri: activeBranch.uri, cid: activeBranch.cid };
+      await createMergeRecord(
+        activeBranch,
+        sheetRef,
+        branchRef,
+        latestCommitRef.current ?? undefined,
+      );
+
+      const updatedBranch = await updateBranchStatus(activeBranch, 'merged');
+      setActiveBranch(updatedBranch);
+      setSheetBranches((prev) => {
+        const next = new Map(prev);
+        const existing = next.get(activeSheetId) ?? [];
+        next.set(
+          activeSheetId,
+          existing.map((b) => (b.id === activeBranch.id ? updatedBranch : b)),
+        );
+        return next;
+      });
+      setMergeDialogOpen(false);
+    } catch (err) {
+      console.warn('[merge] failed:', err);
+      alert('マージに失敗しました。');
+    }
+  }, [activeBranch, activeSheetId, branchCommits, persistFile]);
 
   const handleChange = useCallback(
     (updated: GraphFile) => {
@@ -632,6 +794,7 @@ export default function App() {
         activeBranchId={activeBranch?.id ?? null}
         onSelectBranch={handleSelectBranch}
         onCreateBranch={handleCreateBranch}
+        onDeleteBranch={handleDeleteBranch}
       />
       <main style={{ flex: 1 }}>
         {activeFile && activeSheetId ? (
@@ -687,22 +850,67 @@ export default function App() {
             ⎇ {activeBranch.name}{' '}
             {pendingOps.length > 0 ? `(${pendingOps.length} 変更)` : ''}
           </span>
-          <button
-            type="button"
-            onClick={() => setCommitDialogOpen(true)}
-            disabled={pendingOps.length === 0}
-            style={{
-              padding: '6px 16px',
-              fontSize: 13,
-              background: pendingOps.length > 0 ? '#4f6ef7' : '#ccc',
-              color: '#fff',
-              border: 'none',
-              borderRadius: 4,
-              cursor: pendingOps.length > 0 ? 'pointer' : 'not-allowed',
-            }}
-          >
-            コミット
-          </button>
+          {(() => {
+            const canCommit =
+              pendingOps.length > 0 && activeBranch.status === 'open';
+            const canMerge =
+              pendingOps.length === 0 &&
+              branchCommits.length > 0 &&
+              activeBranch.status === 'open';
+            const canClose = activeBranch.status === 'merged';
+            return (
+              <>
+                <button
+                  type="button"
+                  onClick={() => setCommitDialogOpen(true)}
+                  disabled={!canCommit}
+                  style={{
+                    padding: '6px 16px',
+                    fontSize: 13,
+                    background: canCommit ? '#4f6ef7' : '#ccc',
+                    color: '#fff',
+                    border: 'none',
+                    borderRadius: 4,
+                    cursor: canCommit ? 'pointer' : 'not-allowed',
+                  }}
+                >
+                  コミット
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setMergeDialogOpen(true)}
+                  disabled={!canMerge}
+                  style={{
+                    padding: '6px 16px',
+                    fontSize: 13,
+                    background: canMerge ? '#e67e22' : '#ccc',
+                    color: '#fff',
+                    border: 'none',
+                    borderRadius: 4,
+                    cursor: canMerge ? 'pointer' : 'not-allowed',
+                  }}
+                >
+                  マージ
+                </button>
+                <button
+                  type="button"
+                  onClick={handleClose}
+                  disabled={!canClose}
+                  style={{
+                    padding: '6px 16px',
+                    fontSize: 13,
+                    background: canClose ? '#555' : '#ccc',
+                    color: '#fff',
+                    border: 'none',
+                    borderRadius: 4,
+                    cursor: canClose ? 'pointer' : 'not-allowed',
+                  }}
+                >
+                  クローズ
+                </button>
+              </>
+            );
+          })()}
         </div>
       )}
       {commitDialogOpen && (
@@ -710,6 +918,23 @@ export default function App() {
           operations={pendingOps}
           onCommit={handleCommit}
           onCancel={() => setCommitDialogOpen(false)}
+        />
+      )}
+      {mergeDialogOpen && activeBranch && (
+        <MergeDialog
+          branch={activeBranch}
+          commits={branchCommits}
+          onConfirm={handleMerge}
+          onCancel={() => setMergeDialogOpen(false)}
+        />
+      )}
+      {deleteBranchState && (
+        <BranchDeleteDialog
+          branch={deleteBranchState.branch}
+          commits={deleteBranchState.commits}
+          hasPendingChanges={deleteBranchState.hasPendingChanges}
+          onConfirm={handleConfirmDeleteBranch}
+          onCancel={() => setDeleteBranchState(null)}
         />
       )}
     </div>

--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -88,6 +88,7 @@ export default function App() {
   const [branchCommits, setBranchCommits] = useState<Commit[]>([]);
   const [commitDialogOpen, setCommitDialogOpen] = useState(false);
   const [mergeDialogOpen, setMergeDialogOpen] = useState(false);
+  const [branchHasMerged, setBranchHasMerged] = useState(false);
   const [deleteBranchState, setDeleteBranchState] = useState<{
     sheetId: SheetId;
     branch: Branch;
@@ -218,6 +219,7 @@ export default function App() {
 
   const handleSelectBranch = useCallback(
     async (sheetId: SheetId, branch: Branch | null) => {
+      setBranchHasMerged(false);
       latestCommitRef.current = null;
       if (!branch || branch.name === 'main') {
         setActiveBranch(branch);
@@ -264,6 +266,7 @@ export default function App() {
     branchBaseSheet.current = null;
     branchOriginalBase.current = null;
     setBranchCommits([]);
+    setBranchHasMerged(false);
     // branch 開始前の activeFile を復元 (branch の編集内容は永続化されないため)
     if (preBranchFile.current) {
       setActiveFile(preBranchFile.current);
@@ -350,6 +353,7 @@ export default function App() {
       branchBaseSheet.current = null;
       branchOriginalBase.current = null;
       setBranchCommits([]);
+      setBranchHasMerged(false);
       if (preBranchFile.current) {
         setActiveFile(preBranchFile.current);
         preBranchFile.current = null;
@@ -609,17 +613,15 @@ export default function App() {
         latestCommitRef.current ?? undefined,
       );
 
-      const updatedBranch = await updateBranchStatus(activeBranch, 'merged');
-      setActiveBranch(updatedBranch);
-      setSheetBranches((prev) => {
-        const next = new Map(prev);
-        const existing = next.get(activeSheetId) ?? [];
-        next.set(
-          activeSheetId,
-          existing.map((b) => (b.id === activeBranch.id ? updatedBranch : b)),
-        );
-        return next;
-      });
+      // merge 後: branch を 'open' のまま保持し, commit/diff 状態をリセット
+      // (branch は close するまで繰り返し変更 → commit → merge できる)
+      latestCommitRef.current = null;
+      branchBaseSheet.current = mergedSheet;
+      branchOriginalBase.current = mergedSheet;
+      branchOriginalBaseMap.current.set(activeBranch.uri, mergedSheet);
+      setBranchCommits([]);
+      setBranchBaseVersion((v) => v + 1);
+      setBranchHasMerged(true);
       setMergeDialogOpen(false);
     } catch (err) {
       console.warn('[merge] failed:', err);
@@ -857,7 +859,10 @@ export default function App() {
               pendingOps.length === 0 &&
               branchCommits.length > 0 &&
               activeBranch.status === 'open';
-            const canClose = activeBranch.status === 'merged';
+            const canClose =
+              branchHasMerged &&
+              pendingOps.length === 0 &&
+              branchCommits.length === 0;
             return (
               <>
                 <button

--- a/src/client/src/BranchDeleteDialog.tsx
+++ b/src/client/src/BranchDeleteDialog.tsx
@@ -1,0 +1,139 @@
+import type { Branch, Commit } from './atproto';
+
+type Props = {
+  branch: Branch;
+  commits: Commit[];
+  hasPendingChanges: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+export function BranchDeleteDialog({
+  branch,
+  commits,
+  hasPendingChanges,
+  onConfirm,
+  onCancel,
+}: Props) {
+  const hasUnmergedCommits = commits.length > 0 && branch.status !== 'merged';
+
+  return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: モーダル背景のクリック閉じ
+    // biome-ignore lint/a11y/useKeyWithClickEvents: モーダル背景のクリック閉じ
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.4)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 1000,
+      }}
+      onClick={onCancel}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="branch を削除"
+        style={{
+          background: '#fff',
+          borderRadius: 8,
+          padding: 24,
+          width: 400,
+          maxWidth: '90vw',
+          boxShadow: '0 4px 24px rgba(0,0,0,0.2)',
+        }}
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+      >
+        <h3 style={{ margin: '0 0 16px', fontSize: 16 }}>branch を削除</h3>
+
+        {/* branch 情報 */}
+        <div
+          style={{
+            background: '#f5f5f5',
+            borderRadius: 4,
+            padding: '8px 12px',
+            marginBottom: 16,
+            fontSize: 13,
+          }}
+        >
+          <div style={{ fontFamily: 'monospace', fontWeight: 600 }}>
+            ⎇ {branch.name}
+          </div>
+          {branch.description && (
+            <div style={{ marginTop: 4, color: '#666', fontSize: 12 }}>
+              {branch.description}
+            </div>
+          )}
+          <div style={{ marginTop: 4, fontSize: 12, color: '#888' }}>
+            {commits.length} コミット &nbsp;·&nbsp; 状態:{' '}
+            {statusLabel(branch.status)}
+          </div>
+        </div>
+
+        {/* 警告 */}
+        {(hasPendingChanges || hasUnmergedCommits) && (
+          <div
+            style={{
+              background: '#fff8e1',
+              border: '1px solid #f9a825',
+              borderRadius: 4,
+              padding: '8px 12px',
+              marginBottom: 16,
+              fontSize: 12,
+              color: '#7a5c00',
+            }}
+          >
+            {hasPendingChanges && <div>⚠ 未コミットの変更があります</div>}
+            {hasUnmergedCommits && (
+              <div>⚠ 未マージのコミットが {commits.length} 件あります</div>
+            )}
+          </div>
+        )}
+
+        <div style={{ fontSize: 12, color: '#666', marginBottom: 16 }}>
+          この操作は取り消せません。branch とすべての commit が削除されます。
+        </div>
+
+        {/* ボタン */}
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+          <button
+            type="button"
+            onClick={onCancel}
+            style={{ padding: '6px 16px', fontSize: 13, cursor: 'pointer' }}
+          >
+            キャンセル
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            style={{
+              padding: '6px 16px',
+              fontSize: 13,
+              cursor: 'pointer',
+              background: '#e53935',
+              color: '#fff',
+              border: 'none',
+              borderRadius: 4,
+            }}
+          >
+            削除
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function statusLabel(status: Branch['status']): string {
+  switch (status) {
+    case 'open':
+      return 'オープン';
+    case 'merged':
+      return 'マージ済み';
+    case 'closed':
+      return 'クローズ済み';
+  }
+}

--- a/src/client/src/MergeDialog.tsx
+++ b/src/client/src/MergeDialog.tsx
@@ -1,0 +1,136 @@
+import type { Branch, Commit } from './atproto';
+
+type Props = {
+  branch: Branch;
+  commits: Commit[];
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+export function MergeDialog({ branch, commits, onConfirm, onCancel }: Props) {
+  return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: モーダル背景のクリック閉じ
+    // biome-ignore lint/a11y/useKeyWithClickEvents: モーダル背景のクリック閉じ
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.4)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 1000,
+      }}
+      onClick={onCancel}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="branch をマージ"
+        style={{
+          background: '#fff',
+          borderRadius: 8,
+          padding: 24,
+          width: 440,
+          maxWidth: '90vw',
+          maxHeight: '80vh',
+          display: 'flex',
+          flexDirection: 'column',
+          boxShadow: '0 4px 24px rgba(0,0,0,0.2)',
+        }}
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+      >
+        <h3 style={{ margin: '0 0 16px', fontSize: 16 }}>branch をマージ</h3>
+
+        {/* branch 情報 */}
+        <div
+          style={{
+            background: '#f5f5f5',
+            borderRadius: 4,
+            padding: '8px 12px',
+            marginBottom: 16,
+            fontSize: 13,
+          }}
+        >
+          <div style={{ fontFamily: 'monospace', fontWeight: 600 }}>
+            ⎇ {branch.name}
+          </div>
+          {branch.description && (
+            <div style={{ marginTop: 4, color: '#666', fontSize: 12 }}>
+              {branch.description}
+            </div>
+          )}
+        </div>
+
+        {/* commit 一覧 */}
+        <div style={{ fontSize: 12, color: '#555', marginBottom: 8 }}>
+          マージされる commit ({commits.length} 件)
+        </div>
+        <div
+          style={{
+            flex: 1,
+            overflowY: 'auto',
+            border: '1px solid #eee',
+            borderRadius: 4,
+            marginBottom: 16,
+          }}
+        >
+          {commits.length === 0 ? (
+            <div style={{ padding: '12px', color: '#999', fontSize: 12 }}>
+              commit がありません
+            </div>
+          ) : (
+            commits.map((c) => (
+              <div
+                key={c.id}
+                style={{
+                  padding: '8px 12px',
+                  borderBottom: '1px solid #f0f0f0',
+                  fontSize: 12,
+                }}
+              >
+                <div style={{ fontWeight: 500, marginBottom: 2 }}>
+                  {c.message}
+                </div>
+                <div style={{ color: '#999' }}>
+                  {new Date(c.createdAt).toLocaleString('ja-JP')} &nbsp;·&nbsp;
+                  {c.authorDid.length > 20
+                    ? `${c.authorDid.slice(0, 20)}…`
+                    : c.authorDid}
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+
+        {/* ボタン */}
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+          <button
+            type="button"
+            onClick={onCancel}
+            style={{ padding: '6px 16px', fontSize: 13, cursor: 'pointer' }}
+          >
+            キャンセル
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={commits.length === 0}
+            style={{
+              padding: '6px 16px',
+              fontSize: 13,
+              cursor: commits.length > 0 ? 'pointer' : 'not-allowed',
+              background: commits.length > 0 ? '#e67e22' : '#ccc',
+              color: '#fff',
+              border: 'none',
+              borderRadius: 4,
+            }}
+          >
+            マージ
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/client/src/Sidebar.tsx
+++ b/src/client/src/Sidebar.tsx
@@ -38,6 +38,7 @@ type Props = {
   onDeleteSheet: (sheetId: string) => void;
   onSelectBranch: (sheetId: SheetId, branch: Branch | null) => void;
   onCreateBranch: (sheetId: SheetId) => void;
+  onDeleteBranch: (sheetId: SheetId, branch: Branch) => void;
 };
 
 const gearBtnStyle: React.CSSProperties = {
@@ -75,6 +76,7 @@ export function Sidebar({
   onDeleteSheet,
   onSelectBranch,
   onCreateBranch,
+  onDeleteBranch,
 }: Props) {
   const newFileComposingRef = useRef(false);
   const importInputRef = useRef<HTMLInputElement>(null);
@@ -373,6 +375,7 @@ export function Sidebar({
                                 {bs.map((branch) => {
                                   const isActiveBranch =
                                     activeBranchId === branch.id;
+                                  const isClosed = branch.status === 'closed';
                                   return (
                                     <li key={branch.id}>
                                       <div
@@ -404,7 +407,12 @@ export function Sidebar({
                                             color:
                                               branch.name === 'main'
                                                 ? '#888'
-                                                : '#333',
+                                                : isClosed
+                                                  ? '#bbb'
+                                                  : '#333',
+                                            textDecoration: isClosed
+                                              ? 'line-through'
+                                              : 'none',
                                           }}
                                           onClick={() =>
                                             onSelectBranch(
@@ -420,6 +428,22 @@ export function Sidebar({
                                             ? '⎇ main'
                                             : `⎇ ${branch.name}`}
                                         </button>
+                                        {branch.name !== 'main' && (
+                                          <button
+                                            type="button"
+                                            title="branch を削除"
+                                            style={{
+                                              ...gearBtnStyle,
+                                              fontSize: 11,
+                                            }}
+                                            onClick={(e) => {
+                                              e.stopPropagation();
+                                              onDeleteBranch(s.id, branch);
+                                            }}
+                                          >
+                                            ⚙
+                                          </button>
+                                        )}
                                       </div>
                                     </li>
                                   );

--- a/src/client/src/atproto/branchState.ts
+++ b/src/client/src/atproto/branchState.ts
@@ -15,7 +15,7 @@ import type {
   SheetId,
 } from '@conversensus/shared';
 import { currentDid } from './client';
-import { branches, commits, rkeyFromUri } from './collections';
+import { branches, commits, merges, rkeyFromUri } from './collections';
 import type { BranchRecord, CommitRecord, StrongRef } from './types';
 
 // --- Domain types ---
@@ -342,6 +342,42 @@ export async function createBranch(
     uri: result.uri,
     cid: result.cid,
   };
+}
+
+/** branch の status を更新して PDS に保存 */
+export async function updateBranchStatus(
+  branch: Branch,
+  status: 'open' | 'merged' | 'closed',
+): Promise<Branch> {
+  const current = await branches.get(branch.id);
+  const { $type: _, ...rest } = current.value as BranchRecord;
+  const result = await branches.put(branch.id, { ...rest, status });
+  return { ...branch, status, cid: result.cid };
+}
+
+/** merge レコードを作成して PDS に保存 */
+export async function createMergeRecord(
+  branch: Branch,
+  sheetRef: StrongRef,
+  branchRef: StrongRef,
+  latestCommitRef?: StrongRef,
+): Promise<void> {
+  const mergeId = crypto.randomUUID();
+  await merges.put(mergeId, {
+    sheet: sheetRef,
+    branch: branchRef,
+    message: `Merge branch '${branch.name}'`,
+    authorDid: currentDid(),
+    ...(latestCommitRef && { commit: latestCommitRef }),
+    createdAt: new Date().toISOString(),
+  });
+}
+
+/** branch とその全 commit を PDS から削除 */
+export async function deleteBranchFromPds(branch: Branch): Promise<void> {
+  const branchCommits = await fetchCommitsForBranch(branch.uri);
+  await Promise.all(branchCommits.map((c) => commits.delete(c.id)));
+  await branches.delete(branch.id);
 }
 
 /** commit を作成して ATProto に保存 */

--- a/src/client/src/atproto/collections.ts
+++ b/src/client/src/atproto/collections.ts
@@ -5,6 +5,7 @@ import {
   type EdgeLayoutRecord,
   type EdgeRecord,
   type FileRecord,
+  type MergeRecord,
   type NodeLayoutRecord,
   type NodeRecord,
   NSID,
@@ -254,6 +255,20 @@ export const commits = {
   },
   delete(commitId: string) {
     return deleteRecord(NSID.commit, commitId);
+  },
+};
+
+// --- Merge ---
+
+export const merges = {
+  put(
+    mergeId: string,
+    data: Omit<MergeRecord, '$type'>,
+  ): Promise<RecordResult> {
+    return putRecord(NSID.merge, mergeId, { $type: NSID.merge, ...data });
+  },
+  list() {
+    return listRecords(NSID.merge);
   },
 };
 

--- a/src/client/src/atproto/index.ts
+++ b/src/client/src/atproto/index.ts
@@ -6,8 +6,11 @@ export {
   createBranch,
   createCommit,
   createMainBranch,
+  createMergeRecord,
+  deleteBranchFromPds,
   fetchBranchesForSheet,
   fetchCommitsForBranch,
+  updateBranchStatus,
 } from './branchState';
 export { currentDid, getAgent, login } from './client';
 export {
@@ -41,6 +44,7 @@ export type {
   EdgeLayoutRecord,
   EdgeRecord,
   FileRecord,
+  MergeRecord,
   NodeLayoutRecord,
   NodeRecord,
   RecordResult,

--- a/src/client/src/atproto/types.ts
+++ b/src/client/src/atproto/types.ts
@@ -11,6 +11,7 @@ export const NSID = {
   edgeLayout: 'app.conversensus.graph.edgeLayout',
   branch: 'app.conversensus.graph.branch',
   commit: 'app.conversensus.graph.commit',
+  merge: 'app.conversensus.graph.merge',
 } as const;
 
 export type FileRecord = {
@@ -99,5 +100,15 @@ export type CommitRecord = {
   authorDid: string;
   parentCommit?: StrongRef;
   operations: unknown[]; // CommitOperation[] を JSON として格納
+  createdAt: string;
+};
+
+export type MergeRecord = {
+  $type: typeof NSID.merge;
+  sheet: StrongRef;
+  branch: StrongRef;
+  message: string;
+  authorDid: string;
+  commit?: StrongRef;
   createdAt: string;
 };


### PR DESCRIPTION
## Summary

- **branch merge** (#74): commit 済み branch を trunk にマージし、trunk の ATProto データを更新する。MergeDialog で branch 名・説明・commit 一覧を確認してから実行。
- **branch close** (#74): merge 後に branch を close し trunk view に戻る。サイドバーで閉じた branch は取り消し線・灰色表示。
- **branch delete** (#75): サイドバーのギアボタン (⚙) から branch を削除。BranchDeleteDialog で未コミット変更・未マージ commit の警告を表示。branch レコードと紐づく全 commit を PDS から削除する。

## 状態遷移

| 操作 | コミット | マージ | クローズ |
| --- | --- | --- | --- |
| branch 作成直後 | off | off | off |
| グラフ変更 | on | off | off |
| commit | off | on | off |
| merge | off | off | on |
| close | off | off | off |

## 新規ファイル

- `MergeDialog.tsx` — merge 確認ダイアログ
- `BranchDeleteDialog.tsx` — branch 削除確認ダイアログ

## 新規 ATProto レコード

- `app.conversensus.graph.merge` — merge 履歴を PDS に記録

## Test plan

- [ ] branch を作成してノード/エッジを編集 → commit → マージボタンが有効になることを確認
- [ ] MergeDialog に branch 名・commit 一覧が表示されることを確認
- [ ] マージ後に trunk でマージ内容が反映されていることを確認
- [ ] マージ後にクローズボタンが有効になることを確認
- [ ] クローズ後に trunk view に戻ることを確認
- [ ] サイドバーの閉じた branch が灰色・取り消し線で表示されることを確認
- [ ] branch のギアボタン (⚙) をクリックして BranchDeleteDialog が開くことを確認
- [ ] 未マージ commit がある場合に警告が表示されることを確認
- [ ] 削除後に branch がサイドバーから消えることを確認

Closes #74, #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)