### PR TITLE
test: computeOperations/collections のユニットテスト追加と test.md 欠落の補完 (#83)

### DIFF
--- a/src/client/src/SettingsPopup.test.md
+++ b/src/client/src/SettingsPopup.test.md
@@ -1,0 +1,22 @@
+# SettingsPopup.test.tsx — テスト仕様
+
+## 何をテストするか
+
+`SettingsPopup.tsx` コンポーネント。
+ファイル/シートの名前・概要編集、削除、閉じる操作を提供するポップアップ UI。
+
+## なぜテストするか
+
+- ファイル/シート管理の基本 UI であり、名前の空入力防止・IME 対応など細かい UX 要件がある
+- onSave/onDelete/onClose のコールバック呼び出し条件が複数ある
+- キーボード操作（Enter/Escape）の挙動が仕様通りであることを保証する必要がある
+
+## どのようにテストするか
+
+| カテゴリ | テスト内容 |
+|---------|-----------|
+| 初期表示 | name/description の props が input に反映される |
+| 保存操作 | 保存ボタンで onSave + onClose 呼ばれる。名前変更反映。空文字フォールバック |
+| キーボード | Enter で保存。IME 変換中は抑制。IME 確定後は保存。Escape で保存せずに onClose |
+| 削除 | 削除ボタンで onDelete |
+| 外部クリック | ポップアップ外クリックで onSave + onClose |

--- a/src/client/src/atproto/branchState.test.md
+++ b/src/client/src/atproto/branchState.test.md
@@ -1,0 +1,27 @@
+# branchState.test.ts — テスト仕様
+
+## 何をテストするか
+
+`branchState.ts` の `computeOperations(base, current)` 純粋関数。
+2つの `Sheet` の差分を `CommitOperation[]` として計算する。
+
+## なぜテストするか
+
+- ブランチの orange 表示・pending ops 計算・merge ボタン有効/無効がすべてこの関数の結果に依存している
+- テストが皆無なのはリスクが高い
+- 純粋関数のためモック不要でテストが容易
+
+## どのようにテストするか
+
+| カテゴリ | テスト内容 |
+|---------|-----------|
+| node.add | base にないノードが追加として検出される。properties あり/なし両方を確認 |
+| node.update | content・properties の変化を検出。同一内容で ops 空も確認 |
+| node.remove | current にないノードを削除として検出 |
+| edge.add | base にないエッジを追加として検出。label あり/なし両方を確認 |
+| edge.update | label・properties の変化を検出 |
+| edge.remove | current にないエッジを削除として検出 |
+| 同一シート | base === current で ops が空 |
+| layout 変更 | layouts/edgeLayouts のみの変化は commit 対象外なので ops 空 |
+| 複合操作 | 追加・更新・削除の混在を正しく検出 |
+| エッジケース | 空シート同士、全削除、追加順序の検証 |

--- a/src/client/src/atproto/branchState.test.ts
+++ b/src/client/src/atproto/branchState.test.ts
@@ -1,0 +1,398 @@
+import { describe, expect, it } from 'bun:test';
+import type {
+  EdgeId,
+  GraphEdge,
+  GraphNode,
+  NodeId,
+  Sheet,
+  SheetId,
+} from '@conversensus/shared';
+import { computeOperations } from './branchState';
+
+const sid = '00000000-0000-0000-0000-000000000001' as SheetId;
+
+function emptySheet(): Sheet {
+  return { id: sid, name: 'test', nodes: [], edges: [] };
+}
+
+function n(id: string, content = 'content'): GraphNode {
+  return { id: id as NodeId, content };
+}
+
+function nWithProps(
+  id: string,
+  content: string,
+  props: Record<string, unknown>,
+): GraphNode {
+  return { id: id as NodeId, content, properties: props };
+}
+
+function e(
+  id: string,
+  source: string,
+  target: string,
+  label?: string,
+): GraphEdge {
+  return {
+    id: id as EdgeId,
+    source: source as NodeId,
+    target: target as NodeId,
+    ...(label && { label }),
+  };
+}
+
+function eWithProps(
+  id: string,
+  source: string,
+  target: string,
+  props: Record<string, unknown>,
+): GraphEdge {
+  return {
+    id: id as EdgeId,
+    source: source as NodeId,
+    target: target as NodeId,
+    properties: props,
+  };
+}
+
+// --- node.add ---
+
+describe('computeOperations: node.add', () => {
+  it('base になく current にあるノードは node.add', () => {
+    const ops = computeOperations(emptySheet(), {
+      id: sid,
+      name: 'test',
+      nodes: [n('n1')],
+      edges: [],
+    });
+    expect(ops).toEqual([{ op: 'node.add', nodeId: 'n1', content: 'content' }]);
+  });
+
+  it('properties があるノードの追加', () => {
+    const ops = computeOperations(emptySheet(), {
+      id: sid,
+      name: 'test',
+      nodes: [nWithProps('n1', 'c', { key: 'v' })],
+      edges: [],
+    });
+    expect(ops).toEqual([
+      { op: 'node.add', nodeId: 'n1', content: 'c', properties: { key: 'v' } },
+    ]);
+  });
+});
+
+// --- node.update ---
+
+describe('computeOperations: node.update', () => {
+  it('content が変わると node.update', () => {
+    const base: Sheet = {
+      id: sid,
+      name: 'test',
+      nodes: [n('n1', 'old')],
+      edges: [],
+    };
+    const ops = computeOperations(base, { ...base, nodes: [n('n1', 'new')] });
+    expect(ops).toEqual([{ op: 'node.update', nodeId: 'n1', content: 'new' }]);
+  });
+
+  it('properties が変わると node.update', () => {
+    const base: Sheet = {
+      id: sid,
+      name: 'test',
+      nodes: [nWithProps('n1', 'c', { a: 1 })],
+      edges: [],
+    };
+    const ops = computeOperations(base, {
+      ...base,
+      nodes: [nWithProps('n1', 'c', { a: 2 })],
+    });
+    expect(ops).toEqual([
+      { op: 'node.update', nodeId: 'n1', content: 'c', properties: { a: 2 } },
+    ]);
+  });
+
+  it('properties が追加された場合も node.update', () => {
+    const base: Sheet = {
+      id: sid,
+      name: 'test',
+      nodes: [n('n1', 'c')],
+      edges: [],
+    };
+    const ops = computeOperations(base, {
+      ...base,
+      nodes: [nWithProps('n1', 'c', { new: true })],
+    });
+    expect(ops).toEqual([
+      {
+        op: 'node.update',
+        nodeId: 'n1',
+        content: 'c',
+        properties: { new: true },
+      },
+    ]);
+  });
+
+  it('content も properties も同じなら ops は空', () => {
+    const base: Sheet = {
+      id: sid,
+      name: 'test',
+      nodes: [nWithProps('n1', 'c', { a: 1 })],
+      edges: [],
+    };
+    const ops = computeOperations(base, {
+      ...base,
+      nodes: [nWithProps('n1', 'c', { a: 1 })],
+    });
+    expect(ops).toEqual([]);
+  });
+});
+
+// --- node.remove ---
+
+describe('computeOperations: node.remove', () => {
+  it('current にないノードは node.remove', () => {
+    const base: Sheet = { id: sid, name: 'test', nodes: [n('n1')], edges: [] };
+    const ops = computeOperations(base, emptySheet());
+    expect(ops).toEqual([{ op: 'node.remove', nodeId: 'n1' }]);
+  });
+});
+
+// --- edge.add ---
+
+describe('computeOperations: edge.add', () => {
+  it('base になく current にあるエッジは edge.add', () => {
+    const ops = computeOperations(emptySheet(), {
+      id: sid,
+      name: 'test',
+      nodes: [],
+      edges: [e('e1', 'n1', 'n2', 'label')],
+    });
+    expect(ops).toEqual([
+      {
+        op: 'edge.add',
+        edgeId: 'e1',
+        sourceId: 'n1',
+        targetId: 'n2',
+        label: 'label',
+      },
+    ]);
+  });
+
+  it('label なしのエッジ追加', () => {
+    const ops = computeOperations(emptySheet(), {
+      id: sid,
+      name: 'test',
+      nodes: [],
+      edges: [e('e1', 'n1', 'n2')],
+    });
+    expect(ops).toEqual([
+      { op: 'edge.add', edgeId: 'e1', sourceId: 'n1', targetId: 'n2' },
+    ]);
+  });
+});
+
+// --- edge.update ---
+
+describe('computeOperations: edge.update', () => {
+  it('label が変わると edge.update', () => {
+    const base: Sheet = {
+      id: sid,
+      name: 'test',
+      nodes: [],
+      edges: [e('e1', 'n1', 'n2', 'old')],
+    };
+    const ops = computeOperations(base, {
+      ...base,
+      edges: [e('e1', 'n1', 'n2', 'new')],
+    });
+    expect(ops).toEqual([{ op: 'edge.update', edgeId: 'e1', label: 'new' }]);
+  });
+
+  it('label が undefined に変わったとき edge.update の label が undefined', () => {
+    const base: Sheet = {
+      id: sid,
+      name: 'test',
+      nodes: [],
+      edges: [e('e1', 'n1', 'n2', 'old')],
+    };
+    const ops = computeOperations(base, {
+      ...base,
+      edges: [e('e1', 'n1', 'n2')],
+    });
+    expect(ops).toHaveLength(1);
+    expect(ops[0].op).toBe('edge.update');
+  });
+
+  it('properties が変わると edge.update', () => {
+    const base: Sheet = {
+      id: sid,
+      name: 'test',
+      nodes: [],
+      edges: [eWithProps('e1', 'n1', 'n2', { a: 1 })],
+    };
+    const ops = computeOperations(base, {
+      ...base,
+      edges: [eWithProps('e1', 'n1', 'n2', { a: 2 })],
+    });
+    expect(ops).toEqual([
+      { op: 'edge.update', edgeId: 'e1', properties: { a: 2 } },
+    ]);
+  });
+});
+
+// --- edge.remove ---
+
+describe('computeOperations: edge.remove', () => {
+  it('current にないエッジは edge.remove', () => {
+    const base: Sheet = {
+      id: sid,
+      name: 'test',
+      nodes: [],
+      edges: [e('e1', 'n1', 'n2')],
+    };
+    const ops = computeOperations(base, emptySheet());
+    expect(ops).toEqual([{ op: 'edge.remove', edgeId: 'e1' }]);
+  });
+});
+
+// --- 同一シート ---
+
+describe('computeOperations: 同一シート', () => {
+  it('base と current が同一なら ops は空', () => {
+    const sheet: Sheet = {
+      id: sid,
+      name: 'test',
+      nodes: [n('n1'), n('n2')],
+      edges: [e('e1', 'n1', 'n2', 'rel')],
+    };
+    expect(computeOperations(sheet, sheet)).toEqual([]);
+  });
+});
+
+// --- layout のみの変更 ---
+
+describe('computeOperations: layout 変更は無視', () => {
+  it('layouts が変わっても ops は空', () => {
+    const base: Sheet = { id: sid, name: 'test', nodes: [n('n1')], edges: [] };
+    const current: Sheet = {
+      id: sid,
+      name: 'test',
+      nodes: [n('n1')],
+      edges: [],
+      layouts: [{ nodeId: 'n1' as NodeId, x: 100, y: 200 }],
+    };
+    expect(computeOperations(base, current)).toEqual([]);
+  });
+
+  it('edgeLayouts が変わっても ops は空', () => {
+    const base: Sheet = {
+      id: sid,
+      name: 'test',
+      nodes: [],
+      edges: [e('e1', 'n1', 'n2')],
+    };
+    const current: Sheet = {
+      id: sid,
+      name: 'test',
+      nodes: [],
+      edges: [e('e1', 'n1', 'n2')],
+      edgeLayouts: [{ edgeId: 'e1' as EdgeId, pathType: 'bezier' }],
+    };
+    expect(computeOperations(base, current)).toEqual([]);
+  });
+});
+
+// --- 複合操作 ---
+
+describe('computeOperations: 複合操作', () => {
+  it('追加・更新・削除の混在', () => {
+    const base: Sheet = {
+      id: sid,
+      name: 'test',
+      nodes: [n('n1', 'old'), n('n2')], // n1 更新, n2 削除
+      edges: [e('e1', 'n1', 'n2')], // e1 削除
+    };
+    const current: Sheet = {
+      id: sid,
+      name: 'test',
+      nodes: [n('n1', 'new'), n('n3')], // n1 更新, n3 追加
+      edges: [e('e2', 'n1', 'n3', 'new-edge')], // e2 追加
+    };
+    const ops = computeOperations(base, current);
+    expect(ops).toHaveLength(5);
+    expect(ops).toContainEqual({
+      op: 'node.update',
+      nodeId: 'n1',
+      content: 'new',
+    });
+    expect(ops).toContainEqual({
+      op: 'node.add',
+      nodeId: 'n3',
+      content: 'content',
+    });
+    expect(ops).toContainEqual({ op: 'node.remove', nodeId: 'n2' });
+    expect(ops).toContainEqual({
+      op: 'edge.add',
+      edgeId: 'e2',
+      sourceId: 'n1',
+      targetId: 'n3',
+      label: 'new-edge',
+    });
+    expect(ops).toContainEqual({ op: 'edge.remove', edgeId: 'e1' });
+  });
+});
+
+// --- エッジケース ---
+
+describe('computeOperations: エッジケース', () => {
+  it('空シート同士 → ops は空', () => {
+    expect(computeOperations(emptySheet(), emptySheet())).toEqual([]);
+  });
+
+  it('空シートからのノード追加', () => {
+    const ops = computeOperations(emptySheet(), {
+      id: sid,
+      name: 'test',
+      nodes: [n('n1'), n('n2')],
+      edges: [],
+    });
+    expect(ops).toHaveLength(2);
+    expect(ops).toContainEqual({
+      op: 'node.add',
+      nodeId: 'n1',
+      content: 'content',
+    });
+    expect(ops).toContainEqual({
+      op: 'node.add',
+      nodeId: 'n2',
+      content: 'content',
+    });
+  });
+
+  it('全ノード・全エッジ削除', () => {
+    const base: Sheet = {
+      id: sid,
+      name: 'test',
+      nodes: [n('n1'), n('n2')],
+      edges: [e('e1', 'n1', 'n2')],
+    };
+    const ops = computeOperations(base, emptySheet());
+    expect(ops).toHaveLength(3);
+    expect(ops).toContainEqual({ op: 'node.remove', nodeId: 'n1' });
+    expect(ops).toContainEqual({ op: 'node.remove', nodeId: 'n2' });
+    expect(ops).toContainEqual({ op: 'edge.remove', edgeId: 'e1' });
+  });
+
+  it('ノード追加・エッジ追加の順序', () => {
+    const ops = computeOperations(emptySheet(), {
+      id: sid,
+      name: 'test',
+      nodes: [n('n1'), n('n2')],
+      edges: [e('e1', 'n1', 'n2')],
+    });
+    // node.add が先、edge.add が後
+    const nodeAddIndex = ops.findIndex((o) => o.op === 'node.add');
+    const edgeAddIndex = ops.findIndex((o) => o.op === 'edge.add');
+    expect(nodeAddIndex).toBeLessThan(edgeAddIndex);
+  });
+});

--- a/src/client/src/atproto/collections.test.md
+++ b/src/client/src/atproto/collections.test.md
@@ -1,0 +1,24 @@
+# collections.test.ts — テスト仕様
+
+## 何をテストするか
+
+`collections.ts` の rkey (Record Key) 操作ユーティリティ関数:
+
+- `makeRkey(prefix, id)` — prefix と id から `prefix_id` 形式の rkey を生成
+- `idFromRkey(rkey)` — rkey から id 部分を抽出
+- `prefixFromRkey(rkey)` — rkey から prefix 部分を抽出
+
+## なぜテストするか
+
+- rkey フォーマットのバグは PDS レコードの読み書き全体に波及する
+- `idFromRkey` / `prefixFromRkey` は旧形式 (prefix なし) の後方互換ロジックを持つ
+- シンプルだがクリティカルな関数のため、テストで仕様を明確化する価値がある
+
+## どのようにテストするか
+
+| カテゴリ | テスト内容 |
+|---------|-----------|
+| makeRkey | trunk/branch prefix での rkey 生成 |
+| idFromRkey | 通常形式・旧形式・複数アンダースコアの抽出 |
+| prefixFromRkey | 通常形式・旧形式・複数アンダースコアの抽出 |
+| 往復変換 | makeRkey → idFromRkey / prefixFromRkey が元の値を復元すること |

--- a/src/client/src/atproto/collections.test.ts
+++ b/src/client/src/atproto/collections.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  idFromRkey,
+  makeRkey,
+  prefixFromRkey,
+  TRUNK_PREFIX,
+} from './collections';
+
+describe('makeRkey', () => {
+  it('trunk prefix + uuid → "trunk_uuid"', () => {
+    expect(makeRkey('trunk', 'abc-123')).toBe('trunk_abc-123');
+  });
+
+  it('branch id + uuid → "branchId_uuid"', () => {
+    expect(makeRkey('550e8400-e29b-41d4-a716-446655440000', 'node-uuid')).toBe(
+      '550e8400-e29b-41d4-a716-446655440000_node-uuid',
+    );
+  });
+
+  it('prefix が空文字の場合 "uuid" になる', () => {
+    expect(makeRkey('', 'myid')).toBe('_myid');
+  });
+});
+
+describe('idFromRkey', () => {
+  it('"trunk_uuid" → "uuid"', () => {
+    expect(idFromRkey('trunk_abc-123')).toBe('abc-123');
+  });
+
+  it('"branchId_uuid" → "uuid"', () => {
+    expect(idFromRkey('branch-x_node-y')).toBe('node-y');
+  });
+
+  it('旧形式 (prefix なし) → そのまま返す', () => {
+    expect(idFromRkey('plain-uuid')).toBe('plain-uuid');
+  });
+
+  it('UUID の rkey → そのまま返す (後方互換)', () => {
+    const uuid = '550e8400-e29b-41d4-a716-446655440000';
+    expect(idFromRkey(uuid)).toBe(uuid);
+  });
+
+  it('複数のアンダースコアがある場合、最初の区切りで分割', () => {
+    expect(idFromRkey('prefix_mid_suffix')).toBe('mid_suffix');
+  });
+});
+
+describe('prefixFromRkey', () => {
+  it('"trunk_uuid" → "trunk"', () => {
+    expect(prefixFromRkey('trunk_abc-123')).toBe('trunk');
+  });
+
+  it('"branchId_uuid" → "branchId"', () => {
+    expect(prefixFromRkey('mybranch_node-1')).toBe('mybranch');
+  });
+
+  it('旧形式 (prefix なし) → TRUNK_PREFIX が返る', () => {
+    expect(prefixFromRkey('plain-uuid')).toBe(TRUNK_PREFIX);
+  });
+
+  it('UUID の rkey → TRUNK_PREFIX が返る (後方互換)', () => {
+    const uuid = '550e8400-e29b-41d4-a716-446655440000';
+    expect(prefixFromRkey(uuid)).toBe(TRUNK_PREFIX);
+  });
+
+  it('複数のアンダースコアがある場合、最初の区切りで分割', () => {
+    expect(prefixFromRkey('pre_mid_suf')).toBe('pre');
+  });
+});
+
+describe('makeRkey → idFromRkey 往復', () => {
+  it('trunk prefix で往復', () => {
+    const uuid = '550e8400-e29b-41d4-a716-446655440000';
+    expect(idFromRkey(makeRkey(TRUNK_PREFIX, uuid))).toBe(uuid);
+  });
+
+  it('branch prefix で往復', () => {
+    const branchId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    const nodeId = '11111111-2222-3333-4444-555555555555';
+    expect(idFromRkey(makeRkey(branchId, nodeId))).toBe(nodeId);
+  });
+});
+
+describe('makeRkey → prefixFromRkey 往復', () => {
+  it('任意の prefix が往復で復元される', () => {
+    const rkey = makeRkey('custom-prefix', 'some-id');
+    expect(prefixFromRkey(rkey)).toBe('custom-prefix');
+  });
+
+  it('TRUNK_PREFIX で往復', () => {
+    const rkey = makeRkey(TRUNK_PREFIX, 'my-id');
+    expect(prefixFromRkey(rkey)).toBe(TRUNK_PREFIX);
+  });
+});

--- a/src/client/src/events/applyEvent.test.md
+++ b/src/client/src/events/applyEvent.test.md
@@ -1,0 +1,35 @@
+# applyEvent.test.ts — テスト仕様
+
+## 何をテストするか
+
+`applyEvent.ts` の `applyEvent(event, nodes, edges)` 関数。
+GraphEvent を React Flow のノード/エッジ配列に適用した結果を返す。
+
+## なぜテストするか
+
+- undo/redo の中核であり、誤ったイベント適用はグラフ状態の破壊につながる
+- structure/content/layout/presentation の4カテゴリにまたがる多様なイベント型が存在する
+- 純粋関数なのでテストが容易
+
+## どのようにテストするか
+
+| カテゴリ | テスト内容 |
+|---------|-----------|
+| NODE_ADDED | ノード追加・座標反映・エッジ非影響 |
+| NODE_DELETED | ノード削除・接続エッジ同時削除・無関係エッジ維持 |
+| EDGE_ADDED | エッジ追加・markerEnd 自動付与 |
+| EDGE_DELETED | エッジ削除・ノード非影響 |
+| EDGE_RECONNECTED | source/target 変更・labelOffset リセット |
+| NODES_GROUPED | 親ノード挿入・子ノード parentId/position 更新 |
+| NODES_UNGROUPED | 親削除・子ノード位置復元・parentId 解除 |
+| NODES_PASTED | 既存選択解除・新規追加 |
+| NODES_PASTED_UNDO | 指定 ID のノード/エッジ一括削除 |
+| NODE_RELABELED | data.label 更新 |
+| EDGE_RELABELED | label 更新 |
+| NODE_PROPERTIES_CHANGED | 未実装のため無変更確認 |
+| NODE_MOVED | position 更新 |
+| NODE_RESIZED | style.width/height 更新 |
+| EDGE_STYLE_CHANGED | data に style マージ・既存 data 保持 |
+| NODE_STYLE_CHANGED | style にマージ・既存 style 保持 |
+| EDGE_LABEL_MOVED | labelOffsetX/Y 更新 |
+| round-trip | apply → invert → apply で元の状態に戻ること |

--- a/src/client/src/events/invertEvent.test.md
+++ b/src/client/src/events/invertEvent.test.md
@@ -1,0 +1,27 @@
+# invertEvent.test.ts — テスト仕様
+
+## 何をテストするか
+
+`invertEvent.ts` の `invertEvent(event)` 関数。
+GraphEvent をその逆操作（undo用）に変換する。
+
+## なぜテストするか
+
+- undo 機能の正しさは invert → apply のラウンドトリップで保証される
+- すべてのイベント型に逆操作が定義されている必要がある
+- 二重反転対称性 `invertEvent(invertEvent(e)).type === e.type` が成立することは undo/redo スタックの健全性に直結する
+
+## どのようにテストするか
+
+| カテゴリ | テスト内容 |
+|---------|-----------|
+| NODE_ADDED ↔ NODE_DELETED | 相互変換・二重反転 |
+| EDGE_ADDED ↔ EDGE_DELETED | 相互変換・data 保持 |
+| EDGE_RECONNECTED | from/to 入れ替え |
+| NODES_GROUPED ↔ NODES_UNGROUPED | 相互変換・children 保持 |
+| NODES_PASTED ↔ NODES_PASTED_UNDO | 相互変換・nodeIds/edgeIds 収集・redo 用 data 保持 |
+| NODE_RELABELED / EDGE_RELABELED | from/to 入れ替え |
+| NODE_MOVED / NODE_RESIZED | from/to 入れ替え |
+| EDGE_STYLE_CHANGED / NODE_STYLE_CHANGED | from/to 入れ替え |
+| EDGE_LABEL_MOVED | from/to 入れ替え |
+| 二重反転対称性 | 全イベント型で type が保存されることの網羅テスト |


### PR DESCRIPTION
## Summary
- `computeOperations` のユニットテストを新規追加 (`branchState.test.ts` + `.test.md`)
  - node/edge の add/update/remove、同一シート、layout 変更無視、複合操作、エッジケース をカバー
- `makeRkey`/`idFromRkey`/`prefixFromRkey` のユニットテストを新規追加 (`collections.test.ts` + `.test.md`)
  - 通常形式・旧形式後方互換・往復変換 をカバー
- 既存テストの欠落仕様書を追加: `applyEvent.test.md`, `invertEvent.test.md`, `SettingsPopup.test.md`

## Test plan
- [x] `bun test` 全 209 tests pass
- [x] `bun run lint` pass
- [x] typecheck pass

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)