### PR TITLE
refactor: collections.ts のインターフェース化と branchState 非同期関数の DI 対応 (#84)

### DIFF
--- a/src/client/src/SettingsPopup.test.md
+++ b/src/client/src/SettingsPopup.test.md
@@ -1,0 +1,22 @@
+# SettingsPopup.test.tsx — テスト仕様
+
+## 何をテストするか
+
+`SettingsPopup.tsx` コンポーネント。
+ファイル/シートの名前・概要編集、削除、閉じる操作を提供するポップアップ UI。
+
+## なぜテストするか
+
+- ファイル/シート管理の基本 UI であり、名前の空入力防止・IME 対応など細かい UX 要件がある
+- onSave/onDelete/onClose のコールバック呼び出し条件が複数ある
+- キーボード操作（Enter/Escape）の挙動が仕様通りであることを保証する必要がある
+
+## どのようにテストするか
+
+| カテゴリ | テスト内容 |
+|---------|-----------|
+| 初期表示 | name/description の props が input に反映される |
+| 保存操作 | 保存ボタンで onSave + onClose 呼ばれる。名前変更反映。空文字フォールバック |
+| キーボード | Enter で保存。IME 変換中は抑制。IME 確定後は保存。Escape で保存せずに onClose |
+| 削除 | 削除ボタンで onDelete |
+| 外部クリック | ポップアップ外クリックで onSave + onClose |

--- a/src/client/src/atproto/branchState.test.md
+++ b/src/client/src/atproto/branchState.test.md
@@ -2,16 +2,17 @@
 
 ## 何をテストするか
 
-`branchState.ts` の `computeOperations(base, current)` 純粋関数。
-2つの `Sheet` の差分を `CommitOperation[]` として計算する。
+`branchState.ts` の純粋関数 `computeOperations` と、非同期関数 `fetchBranchesForSheet`, `fetchCommitsForBranch`。
 
 ## なぜテストするか
 
-- ブランチの orange 表示・pending ops 計算・merge ボタン有効/無効がすべてこの関数の結果に依存している
-- テストが皆無なのはリスクが高い
-- 純粋関数のためモック不要でテストが容易
+- ブランチの orange 表示・pending ops 計算・merge ボタン有効/無効がすべて `computeOperations` の結果に依存している
+- PDS アクセスを DI 化したことで非同期関数もテスト可能になった
+- 純粋関数パートはモック不要、非同期パートは in-memory collection でテストできる
 
 ## どのようにテストするか
+
+### computeOperations (純粋関数)
 
 | カテゴリ | テスト内容 |
 |---------|-----------|
@@ -25,3 +26,10 @@
 | layout 変更 | layouts/edgeLayouts のみの変化は commit 対象外なので ops 空 |
 | 複合操作 | 追加・更新・削除の混在を正しく検出 |
 | エッジケース | 空シート同士、全削除、追加順序の検証 |
+
+### 非同期関数 (in-memory DI)
+
+| カテゴリ | テスト内容 |
+|---------|-----------|
+| fetchBranchesForSheet | 空 collection、該当シートのみ取得、全フィールドのマッピング確認 |
+| fetchCommitsForBranch | 空 collection、parentCommit チェーン順の取得、別 branch の commit 非混入 |

--- a/src/client/src/atproto/branchState.test.md
+++ b/src/client/src/atproto/branchState.test.md
@@ -1,0 +1,27 @@
+# branchState.test.ts — テスト仕様
+
+## 何をテストするか
+
+`branchState.ts` の `computeOperations(base, current)` 純粋関数。
+2つの `Sheet` の差分を `CommitOperation[]` として計算する。
+
+## なぜテストするか
+
+- ブランチの orange 表示・pending ops 計算・merge ボタン有効/無効がすべてこの関数の結果に依存している
+- テストが皆無なのはリスクが高い
+- 純粋関数のためモック不要でテストが容易
+
+## どのようにテストするか
+
+| カテゴリ | テスト内容 |
+|---------|-----------|
+| node.add | base にないノードが追加として検出される。properties あり/なし両方を確認 |
+| node.update | content・properties の変化を検出。同一内容で ops 空も確認 |
+| node.remove | current にないノードを削除として検出 |
+| edge.add | base にないエッジを追加として検出。label あり/なし両方を確認 |
+| edge.update | label・properties の変化を検出 |
+| edge.remove | current にないエッジを削除として検出 |
+| 同一シート | base === current で ops が空 |
+| layout 変更 | layouts/edgeLayouts のみの変化は commit 対象外なので ops 空 |
+| 複合操作 | 追加・更新・削除の混在を正しく検出 |
+| エッジケース | 空シート同士、全削除、追加順序の検証 |

--- a/src/client/src/atproto/branchState.test.ts
+++ b/src/client/src/atproto/branchState.test.ts
@@ -1,0 +1,398 @@
+import { describe, expect, it } from 'bun:test';
+import type {
+  EdgeId,
+  GraphEdge,
+  GraphNode,
+  NodeId,
+  Sheet,
+  SheetId,
+} from '@conversensus/shared';
+import { computeOperations } from './branchState';
+
+const sid = '00000000-0000-0000-0000-000000000001' as SheetId;
+
+function emptySheet(): Sheet {
+  return { id: sid, name: 'test', nodes: [], edges: [] };
+}
+
+function n(id: string, content = 'content'): GraphNode {
+  return { id: id as NodeId, content };
+}
+
+function nWithProps(
+  id: string,
+  content: string,
+  props: Record<string, unknown>,
+): GraphNode {
+  return { id: id as NodeId, content, properties: props };
+}
+
+function e(
+  id: string,
+  source: string,
+  target: string,
+  label?: string,
+): GraphEdge {
+  return {
+    id: id as EdgeId,
+    source: source as NodeId,
+    target: target as NodeId,
+    ...(label && { label }),
+  };
+}
+
+function eWithProps(
+  id: string,
+  source: string,
+  target: string,
+  props: Record<string, unknown>,
+): GraphEdge {
+  return {
+    id: id as EdgeId,
+    source: source as NodeId,
+    target: target as NodeId,
+    properties: props,
+  };
+}
+
+// --- node.add ---
+
+describe('computeOperations: node.add', () => {
+  it('base になく current にあるノードは node.add', () => {
+    const ops = computeOperations(emptySheet(), {
+      id: sid,
+      name: 'test',
+      nodes: [n('n1')],
+      edges: [],
+    });
+    expect(ops).toEqual([{ op: 'node.add', nodeId: 'n1', content: 'content' }]);
+  });
+
+  it('properties があるノードの追加', () => {
+    const ops = computeOperations(emptySheet(), {
+      id: sid,
+      name: 'test',
+      nodes: [nWithProps('n1', 'c', { key: 'v' })],
+      edges: [],
+    });
+    expect(ops).toEqual([
+      { op: 'node.add', nodeId: 'n1', content: 'c', properties: { key: 'v' } },
+    ]);
+  });
+});
+
+// --- node.update ---
+
+describe('computeOperations: node.update', () => {
+  it('content が変わると node.update', () => {
+    const base: Sheet = {
+      id: sid,
+      name: 'test',
+      nodes: [n('n1', 'old')],
+      edges: [],
+    };
+    const ops = computeOperations(base, { ...base, nodes: [n('n1', 'new')] });
+    expect(ops).toEqual([{ op: 'node.update', nodeId: 'n1', content: 'new' }]);
+  });
+
+  it('properties が変わると node.update', () => {
+    const base: Sheet = {
+      id: sid,
+      name: 'test',
+      nodes: [nWithProps('n1', 'c', { a: 1 })],
+      edges: [],
+    };
+    const ops = computeOperations(base, {
+      ...base,
+      nodes: [nWithProps('n1', 'c', { a: 2 })],
+    });
+    expect(ops).toEqual([
+      { op: 'node.update', nodeId: 'n1', content: 'c', properties: { a: 2 } },
+    ]);
+  });
+
+  it('properties が追加された場合も node.update', () => {
+    const base: Sheet = {
+      id: sid,
+      name: 'test',
+      nodes: [n('n1', 'c')],
+      edges: [],
+    };
+    const ops = computeOperations(base, {
+      ...base,
+      nodes: [nWithProps('n1', 'c', { new: true })],
+    });
+    expect(ops).toEqual([
+      {
+        op: 'node.update',
+        nodeId: 'n1',
+        content: 'c',
+        properties: { new: true },
+      },
+    ]);
+  });
+
+  it('content も properties も同じなら ops は空', () => {
+    const base: Sheet = {
+      id: sid,
+      name: 'test',
+      nodes: [nWithProps('n1', 'c', { a: 1 })],
+      edges: [],
+    };
+    const ops = computeOperations(base, {
+      ...base,
+      nodes: [nWithProps('n1', 'c', { a: 1 })],
+    });
+    expect(ops).toEqual([]);
+  });
+});
+
+// --- node.remove ---
+
+describe('computeOperations: node.remove', () => {
+  it('current にないノードは node.remove', () => {
+    const base: Sheet = { id: sid, name: 'test', nodes: [n('n1')], edges: [] };
+    const ops = computeOperations(base, emptySheet());
+    expect(ops).toEqual([{ op: 'node.remove', nodeId: 'n1' }]);
+  });
+});
+
+// --- edge.add ---
+
+describe('computeOperations: edge.add', () => {
+  it('base になく current にあるエッジは edge.add', () => {
+    const ops = computeOperations(emptySheet(), {
+      id: sid,
+      name: 'test',
+      nodes: [],
+      edges: [e('e1', 'n1', 'n2', 'label')],
+    });
+    expect(ops).toEqual([
+      {
+        op: 'edge.add',
+        edgeId: 'e1',
+        sourceId: 'n1',
+        targetId: 'n2',
+        label: 'label',
+      },
+    ]);
+  });
+
+  it('label なしのエッジ追加', () => {
+    const ops = computeOperations(emptySheet(), {
+      id: sid,
+      name: 'test',
+      nodes: [],
+      edges: [e('e1', 'n1', 'n2')],
+    });
+    expect(ops).toEqual([
+      { op: 'edge.add', edgeId: 'e1', sourceId: 'n1', targetId: 'n2' },
+    ]);
+  });
+});
+
+// --- edge.update ---
+
+describe('computeOperations: edge.update', () => {
+  it('label が変わると edge.update', () => {
+    const base: Sheet = {
+      id: sid,
+      name: 'test',
+      nodes: [],
+      edges: [e('e1', 'n1', 'n2', 'old')],
+    };
+    const ops = computeOperations(base, {
+      ...base,
+      edges: [e('e1', 'n1', 'n2', 'new')],
+    });
+    expect(ops).toEqual([{ op: 'edge.update', edgeId: 'e1', label: 'new' }]);
+  });
+
+  it('label が undefined に変わったとき edge.update の label が undefined', () => {
+    const base: Sheet = {
+      id: sid,
+      name: 'test',
+      nodes: [],
+      edges: [e('e1', 'n1', 'n2', 'old')],
+    };
+    const ops = computeOperations(base, {
+      ...base,
+      edges: [e('e1', 'n1', 'n2')],
+    });
+    expect(ops).toHaveLength(1);
+    expect(ops[0].op).toBe('edge.update');
+  });
+
+  it('properties が変わると edge.update', () => {
+    const base: Sheet = {
+      id: sid,
+      name: 'test',
+      nodes: [],
+      edges: [eWithProps('e1', 'n1', 'n2', { a: 1 })],
+    };
+    const ops = computeOperations(base, {
+      ...base,
+      edges: [eWithProps('e1', 'n1', 'n2', { a: 2 })],
+    });
+    expect(ops).toEqual([
+      { op: 'edge.update', edgeId: 'e1', properties: { a: 2 } },
+    ]);
+  });
+});
+
+// --- edge.remove ---
+
+describe('computeOperations: edge.remove', () => {
+  it('current にないエッジは edge.remove', () => {
+    const base: Sheet = {
+      id: sid,
+      name: 'test',
+      nodes: [],
+      edges: [e('e1', 'n1', 'n2')],
+    };
+    const ops = computeOperations(base, emptySheet());
+    expect(ops).toEqual([{ op: 'edge.remove', edgeId: 'e1' }]);
+  });
+});
+
+// --- 同一シート ---
+
+describe('computeOperations: 同一シート', () => {
+  it('base と current が同一なら ops は空', () => {
+    const sheet: Sheet = {
+      id: sid,
+      name: 'test',
+      nodes: [n('n1'), n('n2')],
+      edges: [e('e1', 'n1', 'n2', 'rel')],
+    };
+    expect(computeOperations(sheet, sheet)).toEqual([]);
+  });
+});
+
+// --- layout のみの変更 ---
+
+describe('computeOperations: layout 変更は無視', () => {
+  it('layouts が変わっても ops は空', () => {
+    const base: Sheet = { id: sid, name: 'test', nodes: [n('n1')], edges: [] };
+    const current: Sheet = {
+      id: sid,
+      name: 'test',
+      nodes: [n('n1')],
+      edges: [],
+      layouts: [{ nodeId: 'n1' as NodeId, x: 100, y: 200 }],
+    };
+    expect(computeOperations(base, current)).toEqual([]);
+  });
+
+  it('edgeLayouts が変わっても ops は空', () => {
+    const base: Sheet = {
+      id: sid,
+      name: 'test',
+      nodes: [],
+      edges: [e('e1', 'n1', 'n2')],
+    };
+    const current: Sheet = {
+      id: sid,
+      name: 'test',
+      nodes: [],
+      edges: [e('e1', 'n1', 'n2')],
+      edgeLayouts: [{ edgeId: 'e1' as EdgeId, pathType: 'bezier' }],
+    };
+    expect(computeOperations(base, current)).toEqual([]);
+  });
+});
+
+// --- 複合操作 ---
+
+describe('computeOperations: 複合操作', () => {
+  it('追加・更新・削除の混在', () => {
+    const base: Sheet = {
+      id: sid,
+      name: 'test',
+      nodes: [n('n1', 'old'), n('n2')], // n1 更新, n2 削除
+      edges: [e('e1', 'n1', 'n2')], // e1 削除
+    };
+    const current: Sheet = {
+      id: sid,
+      name: 'test',
+      nodes: [n('n1', 'new'), n('n3')], // n1 更新, n3 追加
+      edges: [e('e2', 'n1', 'n3', 'new-edge')], // e2 追加
+    };
+    const ops = computeOperations(base, current);
+    expect(ops).toHaveLength(5);
+    expect(ops).toContainEqual({
+      op: 'node.update',
+      nodeId: 'n1',
+      content: 'new',
+    });
+    expect(ops).toContainEqual({
+      op: 'node.add',
+      nodeId: 'n3',
+      content: 'content',
+    });
+    expect(ops).toContainEqual({ op: 'node.remove', nodeId: 'n2' });
+    expect(ops).toContainEqual({
+      op: 'edge.add',
+      edgeId: 'e2',
+      sourceId: 'n1',
+      targetId: 'n3',
+      label: 'new-edge',
+    });
+    expect(ops).toContainEqual({ op: 'edge.remove', edgeId: 'e1' });
+  });
+});
+
+// --- エッジケース ---
+
+describe('computeOperations: エッジケース', () => {
+  it('空シート同士 → ops は空', () => {
+    expect(computeOperations(emptySheet(), emptySheet())).toEqual([]);
+  });
+
+  it('空シートからのノード追加', () => {
+    const ops = computeOperations(emptySheet(), {
+      id: sid,
+      name: 'test',
+      nodes: [n('n1'), n('n2')],
+      edges: [],
+    });
+    expect(ops).toHaveLength(2);
+    expect(ops).toContainEqual({
+      op: 'node.add',
+      nodeId: 'n1',
+      content: 'content',
+    });
+    expect(ops).toContainEqual({
+      op: 'node.add',
+      nodeId: 'n2',
+      content: 'content',
+    });
+  });
+
+  it('全ノード・全エッジ削除', () => {
+    const base: Sheet = {
+      id: sid,
+      name: 'test',
+      nodes: [n('n1'), n('n2')],
+      edges: [e('e1', 'n1', 'n2')],
+    };
+    const ops = computeOperations(base, emptySheet());
+    expect(ops).toHaveLength(3);
+    expect(ops).toContainEqual({ op: 'node.remove', nodeId: 'n1' });
+    expect(ops).toContainEqual({ op: 'node.remove', nodeId: 'n2' });
+    expect(ops).toContainEqual({ op: 'edge.remove', edgeId: 'e1' });
+  });
+
+  it('ノード追加・エッジ追加の順序', () => {
+    const ops = computeOperations(emptySheet(), {
+      id: sid,
+      name: 'test',
+      nodes: [n('n1'), n('n2')],
+      edges: [e('e1', 'n1', 'n2')],
+    });
+    // node.add が先、edge.add が後
+    const nodeAddIndex = ops.findIndex((o) => o.op === 'node.add');
+    const edgeAddIndex = ops.findIndex((o) => o.op === 'edge.add');
+    expect(nodeAddIndex).toBeLessThan(edgeAddIndex);
+  });
+});

--- a/src/client/src/atproto/branchState.test.ts
+++ b/src/client/src/atproto/branchState.test.ts
@@ -7,7 +7,13 @@ import type {
   Sheet,
   SheetId,
 } from '@conversensus/shared';
-import { computeOperations } from './branchState';
+import {
+  computeOperations,
+  fetchBranchesForSheet,
+  fetchCommitsForBranch,
+} from './branchState';
+import type { BranchStateDeps } from './collectionTypes';
+import { createInMemoryDeps } from './testing/inMemoryCollections';
 
 const sid = '00000000-0000-0000-0000-000000000001' as SheetId;
 
@@ -394,5 +400,166 @@ describe('computeOperations: エッジケース', () => {
     const nodeAddIndex = ops.findIndex((o) => o.op === 'node.add');
     const edgeAddIndex = ops.findIndex((o) => o.op === 'edge.add');
     expect(nodeAddIndex).toBeLessThan(edgeAddIndex);
+  });
+});
+
+// --- Async function tests (with in-memory DI) ---
+
+function setupDeps(): BranchStateDeps {
+  return createInMemoryDeps();
+}
+
+const DID = 'did:plc:test';
+
+describe('fetchBranchesForSheet (async)', () => {
+  it('空の collection からは空配列を返す', async () => {
+    const deps = setupDeps();
+    const result = await fetchBranchesForSheet(
+      '00000000-0000-0000-0000-000000000001' as SheetId,
+      deps,
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('該当シートの branch のみを返す', async () => {
+    const deps = setupDeps();
+    const targetSheetId = '00000000-0000-0000-0000-000000000001' as SheetId;
+    const otherSheetId = '00000000-0000-0000-0000-000000000002' as SheetId;
+
+    await deps.branches.put('b1', {
+      sheet: {
+        uri: `at://${DID}/app.conversensus.graph.sheet/${targetSheetId}`,
+        cid: 'c1',
+      },
+      name: 'branch-1',
+      authorDid: DID,
+      status: 'open',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    await deps.branches.put('b2', {
+      sheet: {
+        uri: `at://${DID}/app.conversensus.graph.sheet/${otherSheetId}`,
+        cid: 'c2',
+      },
+      name: 'branch-2',
+      authorDid: DID,
+      status: 'open',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+
+    const result = await fetchBranchesForSheet(targetSheetId, deps);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('branch-1');
+  });
+
+  it('branch の全フィールドが正しくマッピングされる', async () => {
+    const deps = setupDeps();
+    const sheetId = '00000000-0000-0000-0000-000000000001';
+    const sheetRef = {
+      uri: `at://${DID}/app.conversensus.graph.sheet/${sheetId}`,
+      cid: 'c-sheet',
+    };
+
+    await deps.branches.put('branch-1', {
+      sheet: sheetRef,
+      name: 'feature-x',
+      description: 'test description',
+      authorDid: DID,
+      status: 'open',
+      baseCommit: {
+        uri: `at://${DID}/app.conversensus.graph.commit/commit-1`,
+        cid: 'c-commit',
+      },
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+
+    const result = await fetchBranchesForSheet(sheetId as SheetId, deps);
+    expect(result).toHaveLength(1);
+    const b = result[0];
+    expect(b.id).toBe('branch-1');
+    expect(b.name).toBe('feature-x');
+    expect(b.description).toBe('test description');
+    expect(b.authorDid).toBe(DID);
+    expect(b.status).toBe('open');
+    expect(b.baseCommitUri).toBe(
+      `at://${DID}/app.conversensus.graph.commit/commit-1`,
+    );
+    expect(b.createdAt).toBe('2026-01-01T00:00:00.000Z');
+  });
+});
+
+describe('fetchCommitsForBranch (async)', () => {
+  it('空の collection からは空配列を返す', async () => {
+    const deps = setupDeps();
+    const result = await fetchCommitsForBranch(
+      `at://${DID}/app.conversensus.graph.branch/b1`,
+      deps,
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('該当 branch の commit を parentCommit チェーン順に返す', async () => {
+    const deps = setupDeps();
+    const branchUri = `at://${DID}/app.conversensus.graph.branch/b1`;
+    const sheetUri = `at://${DID}/app.conversensus.graph.sheet/s1`;
+
+    // c2 → c1 (c2 has parent c1, c1 has no parent)
+    await deps.commits.put('c2', {
+      sheet: { uri: sheetUri, cid: 'cs' },
+      branch: { uri: branchUri, cid: 'cb' },
+      message: 'second',
+      authorDid: DID,
+      parentCommit: {
+        uri: `at://${DID}/app.conversensus.graph.commit/c1`,
+        cid: 'cc1',
+      },
+      operations: [],
+      createdAt: '2026-01-02T00:00:00.000Z',
+    });
+    await deps.commits.put('c1', {
+      sheet: { uri: sheetUri, cid: 'cs' },
+      branch: { uri: branchUri, cid: 'cb' },
+      message: 'first',
+      authorDid: DID,
+      operations: [],
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+
+    const result = await fetchCommitsForBranch(branchUri, deps);
+    expect(result).toHaveLength(2);
+    expect(result[0].message).toBe('first');
+    expect(result[0].parentCommitUri).toBeUndefined();
+    expect(result[1].message).toBe('second');
+    expect(result[1].parentCommitUri).toBe(
+      `at://${DID}/app.conversensus.graph.commit/c1`,
+    );
+  });
+
+  it('別 branch の commit は返さない', async () => {
+    const deps = setupDeps();
+    const branch1Uri = `at://${DID}/app.conversensus.graph.branch/b1`;
+    const branch2Uri = `at://${DID}/app.conversensus.graph.branch/b2`;
+    const sheetUri = `at://${DID}/app.conversensus.graph.sheet/s1`;
+
+    await deps.commits.put('c1', {
+      sheet: { uri: sheetUri, cid: 'cs' },
+      branch: { uri: branch1Uri, cid: 'cb1' },
+      message: 'branch1-commit',
+      authorDid: DID,
+      operations: [],
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    await deps.commits.put('c2', {
+      sheet: { uri: sheetUri, cid: 'cs' },
+      branch: { uri: branch2Uri, cid: 'cb2' },
+      message: 'branch2-commit',
+      authorDid: DID,
+      operations: [],
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+
+    const result = await fetchCommitsForBranch(branch1Uri, deps);
+    expect(result).toHaveLength(1);
+    expect(result[0].message).toBe('branch1-commit');
   });
 });

--- a/src/client/src/atproto/branchState.ts
+++ b/src/client/src/atproto/branchState.ts
@@ -36,6 +36,7 @@ import {
   sheets,
   TRUNK_PREFIX,
 } from './collections';
+import type { BranchStateDeps } from './collectionTypes';
 import {
   edgeLayoutToRecord,
   edgeToRecord,
@@ -170,13 +171,28 @@ export function computeOperations(
   return ops;
 }
 
+// --- DI defaults ---
+
+/** 実 PDS collection に接続されたデフォルトの依存 */
+const defaultDeps: BranchStateDeps = {
+  branches: branches as BranchStateDeps['branches'],
+  commits: commits as BranchStateDeps['commits'],
+  merges: merges as BranchStateDeps['merges'],
+  nodes: nodes as BranchStateDeps['nodes'],
+  edges: edges as BranchStateDeps['edges'],
+  nodeLayouts: nodeLayouts as BranchStateDeps['nodeLayouts'],
+  edgeLayouts: edgeLayouts as BranchStateDeps['edgeLayouts'],
+  sheets: sheets as BranchStateDeps['sheets'],
+};
+
 // --- ATProto helpers ---
 
 /** sheet に紐づく全 branch を取得 */
 export async function fetchBranchesForSheet(
   sheetId: SheetId,
+  deps: BranchStateDeps = defaultDeps,
 ): Promise<Branch[]> {
-  const all = await branches.list();
+  const all = await deps.branches.list();
   return all
     .filter((r) => {
       const rec = r.value as BranchRecord;
@@ -202,8 +218,9 @@ export async function fetchBranchesForSheet(
 /** branch に紐づく全 commit を parentCommit チェーンの順に返す */
 export async function fetchCommitsForBranch(
   branchUri: string,
+  deps: BranchStateDeps = defaultDeps,
 ): Promise<Commit[]> {
-  const all = await commits.list();
+  const all = await deps.commits.list();
   const forBranch = all
     .filter((r) => {
       const rec = r.value as CommitRecord;
@@ -246,11 +263,12 @@ function sortCommitChain(commitList: Commit[]): Commit[] {
 export async function createMainBranch(
   sheetId: SheetId,
   sheetRef: StrongRef,
+  deps: BranchStateDeps = defaultDeps,
 ): Promise<Branch> {
   const branchId = crypto.randomUUID();
   const now = new Date().toISOString();
   const authorDid = currentDid();
-  const result = await branches.put(branchId, {
+  const result = await deps.branches.put(branchId, {
     sheet: sheetRef,
     name: 'trunk',
     authorDid,
@@ -282,13 +300,16 @@ type TrunkSheetData = {
   edgeLayouts: Array<{ layout: EdgeLayout; edgeRef: StrongRef }>;
 };
 
-async function fetchTrunkSheetData(sheetId: SheetId): Promise<TrunkSheetData> {
+async function fetchTrunkSheetData(
+  sheetId: SheetId,
+  deps: BranchStateDeps,
+): Promise<TrunkSheetData> {
   const [allNodes, allEdges, allNodeLayouts, allEdgeLayouts] =
     await Promise.all([
-      nodes.listForPrefix(TRUNK_PREFIX),
-      edges.listForPrefix(TRUNK_PREFIX),
-      nodeLayouts.listForPrefix(TRUNK_PREFIX),
-      edgeLayouts.listForPrefix(TRUNK_PREFIX),
+      deps.nodes.listForPrefix(TRUNK_PREFIX),
+      deps.edges.listForPrefix(TRUNK_PREFIX),
+      deps.nodeLayouts.listForPrefix(TRUNK_PREFIX),
+      deps.edgeLayouts.listForPrefix(TRUNK_PREFIX),
     ]);
 
   const sheetNodes = allNodes.filter(
@@ -376,13 +397,14 @@ export async function createBranch(
   sheetId: SheetId,
   sheetRef: StrongRef,
   baseCommitRef?: StrongRef,
+  deps: BranchStateDeps = defaultDeps,
 ): Promise<Branch> {
   const branchId = crypto.randomUUID();
   const now = new Date().toISOString();
   const authorDid = currentDid();
 
   // Phase 1: BranchRecord を 'creating' で作成
-  await branches.put(branchId, {
+  await deps.branches.put(branchId, {
     sheet: sheetRef,
     name,
     authorDid,
@@ -392,13 +414,16 @@ export async function createBranch(
   });
 
   // Phase 2: trunk の records を branch prefix でコピー
-  const trunkData = await fetchTrunkSheetData(sheetId);
+  const trunkData = await fetchTrunkSheetData(sheetId, deps);
 
   const nodeIdToBranchRef = new Map<string, StrongRef>();
   await Promise.all(
     trunkData.nodes.map(async ({ node }) => {
       const rkey = makeRkey(branchId, node.id);
-      const result = await nodes.put(rkey, nodeToRecord(node, sheetRef, now));
+      const result = await deps.nodes.put(
+        rkey,
+        nodeToRecord(node, sheetRef, now),
+      );
       nodeIdToBranchRef.set(node.id, { uri: result.uri, cid: result.cid });
     }),
   );
@@ -410,7 +435,7 @@ export async function createBranch(
       const targetRef = nodeIdToBranchRef.get(edge.target);
       if (!sourceRef || !targetRef) return;
       const rkey = makeRkey(branchId, edge.id);
-      const result = await edges.put(
+      const result = await deps.edges.put(
         rkey,
         edgeToRecord(edge, sheetRef, sourceRef, targetRef, now),
       );
@@ -426,7 +451,7 @@ export async function createBranch(
         ? nodeIdToBranchRef.get(layout.parentId)
         : undefined;
       const rkey = makeRkey(branchId, layout.nodeId);
-      await nodeLayouts.put(
+      await deps.nodeLayouts.put(
         rkey,
         nodeLayoutToRecord(layout, nodeRef, parentRef, now),
       );
@@ -438,12 +463,15 @@ export async function createBranch(
       const edgeRef = edgeIdToBranchRef.get(layout.edgeId);
       if (!edgeRef) return;
       const rkey = makeRkey(branchId, layout.edgeId);
-      await edgeLayouts.put(rkey, edgeLayoutToRecord(layout, edgeRef, now));
+      await deps.edgeLayouts.put(
+        rkey,
+        edgeLayoutToRecord(layout, edgeRef, now),
+      );
     }),
   );
 
   // Phase 3: BranchRecord を 'open' に更新
-  const openResult = await branches.put(branchId, {
+  const openResult = await deps.branches.put(branchId, {
     sheet: sheetRef,
     name,
     authorDid,
@@ -469,10 +497,11 @@ export async function createBranch(
 export async function updateBranchStatus(
   branch: Branch,
   status: 'open' | 'merged' | 'closed',
+  deps: BranchStateDeps = defaultDeps,
 ): Promise<Branch> {
-  const current = await branches.get(branch.id);
+  const current = await deps.branches.get(branch.id);
   const { $type: _, ...rest } = current.value as BranchRecord;
-  const result = await branches.put(branch.id, { ...rest, status });
+  const result = await deps.branches.put(branch.id, { ...rest, status });
   return { ...branch, status, cid: result.cid };
 }
 
@@ -480,14 +509,15 @@ export async function updateBranchStatus(
 export async function fetchBranchSheetFromPds(
   branchId: string,
   sheetId: SheetId,
+  deps: BranchStateDeps = defaultDeps,
 ): Promise<Sheet> {
   const [sheetEntry, allNodes, allEdges, allNodeLayouts, allEdgeLayouts] =
     await Promise.all([
-      sheets.get(sheetId),
-      nodes.listForPrefix(branchId),
-      edges.listForPrefix(branchId),
-      nodeLayouts.listForPrefix(branchId),
-      edgeLayouts.listForPrefix(branchId),
+      deps.sheets.get(sheetId),
+      deps.nodes.listForPrefix(branchId),
+      deps.edges.listForPrefix(branchId),
+      deps.nodeLayouts.listForPrefix(branchId),
+      deps.edgeLayouts.listForPrefix(branchId),
     ]);
 
   const sheetNodeEntries = allNodes.filter(
@@ -542,6 +572,7 @@ export async function syncBranchSheetToAtproto(
   sheet: Sheet,
   sheetRef: StrongRef,
   branchId: string,
+  deps: BranchStateDeps = defaultDeps,
 ): Promise<void> {
   const now = new Date().toISOString();
   const sheetId = sheet.id;
@@ -551,7 +582,10 @@ export async function syncBranchSheetToAtproto(
   await Promise.all(
     sheet.nodes.map(async (node) => {
       const rkey = makeRkey(branchId, node.id);
-      const result = await nodes.put(rkey, nodeToRecord(node, sheetRef, now));
+      const result = await deps.nodes.put(
+        rkey,
+        nodeToRecord(node, sheetRef, now),
+      );
       nodeIdToRef.set(node.id, { uri: result.uri, cid: result.cid });
     }),
   );
@@ -569,7 +603,7 @@ export async function syncBranchSheetToAtproto(
         return;
       }
       const rkey = makeRkey(branchId, edge.id);
-      const result = await edges.put(
+      const result = await deps.edges.put(
         rkey,
         edgeToRecord(edge, sheetRef, sourceRef, targetRef, now),
       );
@@ -587,7 +621,7 @@ export async function syncBranchSheetToAtproto(
           ? nodeIdToRef.get(layout.parentId)
           : undefined;
         const rkey = makeRkey(branchId, layout.nodeId);
-        await nodeLayouts.put(
+        await deps.nodeLayouts.put(
           rkey,
           nodeLayoutToRecord(layout, nodeRef, parentRef, now),
         );
@@ -602,7 +636,10 @@ export async function syncBranchSheetToAtproto(
         const edgeRef = edgeIdToRef.get(layout.edgeId);
         if (!edgeRef) return;
         const rkey = makeRkey(branchId, layout.edgeId);
-        await edgeLayouts.put(rkey, edgeLayoutToRecord(layout, edgeRef, now));
+        await deps.edgeLayouts.put(
+          rkey,
+          edgeLayoutToRecord(layout, edgeRef, now),
+        );
       }),
     );
   }
@@ -613,6 +650,7 @@ export async function syncBranchSheetToAtproto(
     sheet.edges.map((e) => e.id as string),
     branchId,
     sheetId,
+    deps,
   );
 }
 
@@ -621,10 +659,11 @@ async function cleanupBranchDeletedRecords(
   currentEdgeIds: string[],
   branchId: string,
   sheetId: SheetId,
+  deps: BranchStateDeps,
 ): Promise<void> {
   const [existingNodes, existingEdges] = await Promise.all([
-    nodes.listForPrefix(branchId),
-    edges.listForPrefix(branchId),
+    deps.nodes.listForPrefix(branchId),
+    deps.edges.listForPrefix(branchId),
   ]);
 
   const currentNodeIdSet = new Set(currentNodeIds);
@@ -640,7 +679,7 @@ async function cleanupBranchDeletedRecords(
           !currentNodeIdSet.has(nodeId)
         );
       })
-      .map((r) => nodes.delete(rkeyFromUri(r.uri))),
+      .map((r) => deps.nodes.delete(rkeyFromUri(r.uri))),
     ...existingEdges
       .filter((r) => {
         const rec = r.value as EdgeRecord;
@@ -650,7 +689,7 @@ async function cleanupBranchDeletedRecords(
           !currentEdgeIdSet.has(edgeId)
         );
       })
-      .map((r) => edges.delete(rkeyFromUri(r.uri))),
+      .map((r) => deps.edges.delete(rkeyFromUri(r.uri))),
   ]);
 }
 
@@ -659,15 +698,16 @@ export async function mergeBranchToTrunk(
   branch: Branch,
   sheetId: SheetId,
   sheetRef: StrongRef,
+  deps: BranchStateDeps = defaultDeps,
 ): Promise<void> {
   const _now = new Date().toISOString();
 
   const [branchNodes, branchEdges, branchNodeLayouts, branchEdgeLayouts] =
     await Promise.all([
-      nodes.listForPrefix(branch.id),
-      edges.listForPrefix(branch.id),
-      nodeLayouts.listForPrefix(branch.id),
-      edgeLayouts.listForPrefix(branch.id),
+      deps.nodes.listForPrefix(branch.id),
+      deps.edges.listForPrefix(branch.id),
+      deps.nodeLayouts.listForPrefix(branch.id),
+      deps.edgeLayouts.listForPrefix(branch.id),
     ]);
 
   const sheetBranchNodes = branchNodes.filter(
@@ -687,7 +727,10 @@ export async function mergeBranchToTrunk(
       const rec = r.value as NodeRecord;
       const { $type: _, ...data } = rec;
       const trunkRkey = makeRkey(TRUNK_PREFIX, nodeId);
-      const result = await nodes.put(trunkRkey, { ...data, sheet: sheetRef });
+      const result = await deps.nodes.put(trunkRkey, {
+        ...data,
+        sheet: sheetRef,
+      });
       nodeIdToTrunkRef.set(nodeId, { uri: result.uri, cid: result.cid });
     }),
   );
@@ -705,7 +748,7 @@ export async function mergeBranchToTrunk(
       if (!sourceRef || !targetRef) return;
       const { $type: _, ...data } = rec;
       const trunkRkey = makeRkey(TRUNK_PREFIX, edgeId);
-      const result = await edges.put(trunkRkey, {
+      const result = await deps.edges.put(trunkRkey, {
         ...data,
         sheet: sheetRef,
         source: sourceRef,
@@ -717,8 +760,8 @@ export async function mergeBranchToTrunk(
 
   // 3. branch で削除されたノード/エッジを trunk からも削除
   const [trunkNodes, trunkEdges] = await Promise.all([
-    nodes.listForPrefix(TRUNK_PREFIX),
-    edges.listForPrefix(TRUNK_PREFIX),
+    deps.nodes.listForPrefix(TRUNK_PREFIX),
+    deps.edges.listForPrefix(TRUNK_PREFIX),
   ]);
   const branchNodeIds = new Set(
     sheetBranchNodes.map((r) => idFromRkey(rkeyFromUri(r.uri))),
@@ -736,7 +779,7 @@ export async function mergeBranchToTrunk(
           !branchNodeIds.has(idFromRkey(rkeyFromUri(r.uri)))
         );
       })
-      .map((r) => nodes.delete(rkeyFromUri(r.uri))),
+      .map((r) => deps.nodes.delete(rkeyFromUri(r.uri))),
     ...trunkEdges
       .filter((r) => {
         const rec = r.value as EdgeRecord;
@@ -745,7 +788,7 @@ export async function mergeBranchToTrunk(
           !branchEdgeIds.has(idFromRkey(rkeyFromUri(r.uri)))
         );
       })
-      .map((r) => edges.delete(rkeyFromUri(r.uri))),
+      .map((r) => deps.edges.delete(rkeyFromUri(r.uri))),
   ]);
 
   // 4. nodeLayouts / edgeLayouts → trunk rkey で PUT
@@ -765,7 +808,7 @@ export async function mergeBranchToTrunk(
         const parentRef = parentId ? nodeIdToTrunkRef.get(parentId) : undefined;
         const { $type: _, ...data } = rec;
         const trunkRkey = makeRkey(TRUNK_PREFIX, nodeId);
-        await nodeLayouts.put(trunkRkey, {
+        await deps.nodeLayouts.put(trunkRkey, {
           ...data,
           node: trunkNodeRef,
           ...(parentRef && { parent: parentRef }),
@@ -782,7 +825,10 @@ export async function mergeBranchToTrunk(
         if (!trunkEdgeRef) return;
         const { $type: _, ...data } = rec;
         const trunkRkey = makeRkey(TRUNK_PREFIX, edgeId);
-        await edgeLayouts.put(trunkRkey, { ...data, edge: trunkEdgeRef });
+        await deps.edgeLayouts.put(trunkRkey, {
+          ...data,
+          edge: trunkEdgeRef,
+        });
       }),
   ]);
 }
@@ -793,9 +839,10 @@ export async function createMergeRecord(
   sheetRef: StrongRef,
   branchRef: StrongRef,
   latestCommitRef?: StrongRef,
+  deps: BranchStateDeps = defaultDeps,
 ): Promise<void> {
   const mergeId = crypto.randomUUID();
-  await merges.put(mergeId, {
+  await deps.merges.put(mergeId, {
     sheet: sheetRef,
     branch: branchRef,
     message: `Merge branch '${branch.name}'`,
@@ -806,7 +853,10 @@ export async function createMergeRecord(
 }
 
 /** branch とその全 node/edge/layout/commit レコードを PDS から削除 */
-export async function deleteBranchWithRecords(branch: Branch): Promise<void> {
+export async function deleteBranchWithRecords(
+  branch: Branch,
+  deps: BranchStateDeps = defaultDeps,
+): Promise<void> {
   const [
     branchNodes,
     branchEdges,
@@ -814,20 +864,24 @@ export async function deleteBranchWithRecords(branch: Branch): Promise<void> {
     branchEdgeLayouts,
     branchCommits,
   ] = await Promise.all([
-    nodes.listForPrefix(branch.id),
-    edges.listForPrefix(branch.id),
-    nodeLayouts.listForPrefix(branch.id),
-    edgeLayouts.listForPrefix(branch.id),
-    fetchCommitsForBranch(branch.uri),
+    deps.nodes.listForPrefix(branch.id),
+    deps.edges.listForPrefix(branch.id),
+    deps.nodeLayouts.listForPrefix(branch.id),
+    deps.edgeLayouts.listForPrefix(branch.id),
+    fetchCommitsForBranch(branch.uri, deps),
   ]);
 
   await Promise.all([
-    ...branchNodes.map((r) => nodes.delete(rkeyFromUri(r.uri))),
-    ...branchEdges.map((r) => edges.delete(rkeyFromUri(r.uri))),
-    ...branchNodeLayouts.map((r) => nodeLayouts.delete(rkeyFromUri(r.uri))),
-    ...branchEdgeLayouts.map((r) => edgeLayouts.delete(rkeyFromUri(r.uri))),
-    ...branchCommits.map((c) => commits.delete(c.id)),
-    branches.delete(branch.id),
+    ...branchNodes.map((r) => deps.nodes.delete(rkeyFromUri(r.uri))),
+    ...branchEdges.map((r) => deps.edges.delete(rkeyFromUri(r.uri))),
+    ...branchNodeLayouts.map((r) =>
+      deps.nodeLayouts.delete(rkeyFromUri(r.uri)),
+    ),
+    ...branchEdgeLayouts.map((r) =>
+      deps.edgeLayouts.delete(rkeyFromUri(r.uri)),
+    ),
+    ...branchCommits.map((c) => deps.commits.delete(c.id)),
+    deps.branches.delete(branch.id),
   ]);
 }
 
@@ -839,11 +893,12 @@ export async function createCommit(
   branchRef: StrongRef,
   parentCommitRef?: StrongRef,
   treeRefs?: StrongRef[],
+  deps: BranchStateDeps = defaultDeps,
 ): Promise<Commit> {
   const commitId = crypto.randomUUID();
   const now = new Date().toISOString();
   const authorDid = currentDid();
-  const result = await commits.put(commitId, {
+  const result = await deps.commits.put(commitId, {
     sheet: sheetRef,
     branch: branchRef,
     message,

--- a/src/client/src/atproto/collectionTypes.ts
+++ b/src/client/src/atproto/collectionTypes.ts
@@ -1,0 +1,38 @@
+import type { RecordResult, StrongRef } from './types';
+
+/** PDS record with URI and CID */
+export type RecordEntry<T = unknown> = {
+  uri: string;
+  cid: string;
+  value: T;
+};
+
+/** Minimal interface for repo-level record CRUD — what branchState needs from each collection */
+export interface CollectionCRUD<T = unknown> {
+  put(rkey: string, data: T): Promise<RecordResult>;
+  get(rkey: string): Promise<RecordEntry<T>>;
+  list(): Promise<RecordEntry<T>[]>;
+  delete(rkey: string): Promise<void>;
+}
+
+/** Nodes / Edges / Layouts also support prefix listing */
+export interface PrefixListable<T = unknown> extends CollectionCRUD<T> {
+  listForPrefix(prefix: string): Promise<RecordEntry<T>[]>;
+}
+
+/** Collections that support building a StrongRef from id */
+export interface Refable {
+  ref(id: string): Promise<StrongRef>;
+}
+
+/** The set of collection objects used by branch/commit domain functions */
+export interface BranchStateDeps {
+  branches: CollectionCRUD & Refable;
+  commits: CollectionCRUD;
+  merges: Pick<CollectionCRUD, 'put'>;
+  nodes: PrefixListable;
+  edges: PrefixListable;
+  nodeLayouts: PrefixListable;
+  edgeLayouts: PrefixListable;
+  sheets: Pick<CollectionCRUD, 'get'>;
+}

--- a/src/client/src/atproto/collections.test.md
+++ b/src/client/src/atproto/collections.test.md
@@ -1,0 +1,24 @@
+# collections.test.ts — テスト仕様
+
+## 何をテストするか
+
+`collections.ts` の rkey (Record Key) 操作ユーティリティ関数:
+
+- `makeRkey(prefix, id)` — prefix と id から `prefix_id` 形式の rkey を生成
+- `idFromRkey(rkey)` — rkey から id 部分を抽出
+- `prefixFromRkey(rkey)` — rkey から prefix 部分を抽出
+
+## なぜテストするか
+
+- rkey フォーマットのバグは PDS レコードの読み書き全体に波及する
+- `idFromRkey` / `prefixFromRkey` は旧形式 (prefix なし) の後方互換ロジックを持つ
+- シンプルだがクリティカルな関数のため、テストで仕様を明確化する価値がある
+
+## どのようにテストするか
+
+| カテゴリ | テスト内容 |
+|---------|-----------|
+| makeRkey | trunk/branch prefix での rkey 生成 |
+| idFromRkey | 通常形式・旧形式・複数アンダースコアの抽出 |
+| prefixFromRkey | 通常形式・旧形式・複数アンダースコアの抽出 |
+| 往復変換 | makeRkey → idFromRkey / prefixFromRkey が元の値を復元すること |

--- a/src/client/src/atproto/collections.test.ts
+++ b/src/client/src/atproto/collections.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  idFromRkey,
+  makeRkey,
+  prefixFromRkey,
+  TRUNK_PREFIX,
+} from './collections';
+
+describe('makeRkey', () => {
+  it('trunk prefix + uuid → "trunk_uuid"', () => {
+    expect(makeRkey('trunk', 'abc-123')).toBe('trunk_abc-123');
+  });
+
+  it('branch id + uuid → "branchId_uuid"', () => {
+    expect(makeRkey('550e8400-e29b-41d4-a716-446655440000', 'node-uuid')).toBe(
+      '550e8400-e29b-41d4-a716-446655440000_node-uuid',
+    );
+  });
+
+  it('prefix が空文字の場合 "uuid" になる', () => {
+    expect(makeRkey('', 'myid')).toBe('_myid');
+  });
+});
+
+describe('idFromRkey', () => {
+  it('"trunk_uuid" → "uuid"', () => {
+    expect(idFromRkey('trunk_abc-123')).toBe('abc-123');
+  });
+
+  it('"branchId_uuid" → "uuid"', () => {
+    expect(idFromRkey('branch-x_node-y')).toBe('node-y');
+  });
+
+  it('旧形式 (prefix なし) → そのまま返す', () => {
+    expect(idFromRkey('plain-uuid')).toBe('plain-uuid');
+  });
+
+  it('UUID の rkey → そのまま返す (後方互換)', () => {
+    const uuid = '550e8400-e29b-41d4-a716-446655440000';
+    expect(idFromRkey(uuid)).toBe(uuid);
+  });
+
+  it('複数のアンダースコアがある場合、最初の区切りで分割', () => {
+    expect(idFromRkey('prefix_mid_suffix')).toBe('mid_suffix');
+  });
+});
+
+describe('prefixFromRkey', () => {
+  it('"trunk_uuid" → "trunk"', () => {
+    expect(prefixFromRkey('trunk_abc-123')).toBe('trunk');
+  });
+
+  it('"branchId_uuid" → "branchId"', () => {
+    expect(prefixFromRkey('mybranch_node-1')).toBe('mybranch');
+  });
+
+  it('旧形式 (prefix なし) → TRUNK_PREFIX が返る', () => {
+    expect(prefixFromRkey('plain-uuid')).toBe(TRUNK_PREFIX);
+  });
+
+  it('UUID の rkey → TRUNK_PREFIX が返る (後方互換)', () => {
+    const uuid = '550e8400-e29b-41d4-a716-446655440000';
+    expect(prefixFromRkey(uuid)).toBe(TRUNK_PREFIX);
+  });
+
+  it('複数のアンダースコアがある場合、最初の区切りで分割', () => {
+    expect(prefixFromRkey('pre_mid_suf')).toBe('pre');
+  });
+});
+
+describe('makeRkey → idFromRkey 往復', () => {
+  it('trunk prefix で往復', () => {
+    const uuid = '550e8400-e29b-41d4-a716-446655440000';
+    expect(idFromRkey(makeRkey(TRUNK_PREFIX, uuid))).toBe(uuid);
+  });
+
+  it('branch prefix で往復', () => {
+    const branchId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    const nodeId = '11111111-2222-3333-4444-555555555555';
+    expect(idFromRkey(makeRkey(branchId, nodeId))).toBe(nodeId);
+  });
+});
+
+describe('makeRkey → prefixFromRkey 往復', () => {
+  it('任意の prefix が往復で復元される', () => {
+    const rkey = makeRkey('custom-prefix', 'some-id');
+    expect(prefixFromRkey(rkey)).toBe('custom-prefix');
+  });
+
+  it('TRUNK_PREFIX で往復', () => {
+    const rkey = makeRkey(TRUNK_PREFIX, 'my-id');
+    expect(prefixFromRkey(rkey)).toBe(TRUNK_PREFIX);
+  });
+});

--- a/src/client/src/atproto/testing/inMemoryCollections.ts
+++ b/src/client/src/atproto/testing/inMemoryCollections.ts
@@ -1,0 +1,125 @@
+/**
+ * In-memory collection implementations for testing.
+ *
+ * Each collection stores records keyed by rkey and supports the same interface
+ * as the real PDS-backed collections in `../collections.ts`.
+ */
+
+import type { RecordResult, StrongRef } from '../types';
+
+let _counter = 0;
+
+function nextCid(): string {
+  _counter += 1;
+  return `bafy-test-cid-${_counter}`;
+}
+
+function makeUri(collection: string, rkey: string): string {
+  return `at://did:plc:test/${collection}/${rkey}`;
+}
+
+// ---- generic in-memory record store ----
+
+function createInMemoryStore<T>() {
+  const records = new Map<string, { uri: string; cid: string; value: T }>();
+
+  return {
+    put(rkey: string, data: T): Promise<RecordResult> {
+      const uri = makeUri('test.collection', rkey);
+      const cid = nextCid();
+      records.set(rkey, { uri, cid, value: data });
+      return Promise.resolve({ uri, cid });
+    },
+
+    get(rkey: string) {
+      const entry = records.get(rkey);
+      if (!entry) throw new Error(`Record not found: ${rkey}`);
+      return Promise.resolve(entry);
+    },
+
+    list() {
+      return Promise.resolve(Array.from(records.values()));
+    },
+
+    delete(rkey: string): Promise<void> {
+      records.delete(rkey);
+      return Promise.resolve();
+    },
+
+    listForPrefix(prefix: string) {
+      const results = Array.from(records.entries())
+        .filter(([rkey]) => rkey.startsWith(`${prefix}_`))
+        .map(([, v]) => v);
+      return Promise.resolve(results);
+    },
+
+    ref(rkey: string): Promise<StrongRef> {
+      const entry = records.get(rkey);
+      if (!entry) throw new Error(`Record not found: ${rkey}`);
+      return Promise.resolve({ uri: entry.uri, cid: entry.cid });
+    },
+
+    refFromResult(_rkey: string, result: RecordResult): StrongRef {
+      return { uri: result.uri, cid: result.cid };
+    },
+
+    /** Expose raw map for test assertions */
+    _records: records,
+  };
+}
+
+// ---- typed collection factories ----
+
+export function createInMemoryBranches() {
+  return createInMemoryStore<Record<string, unknown>>();
+}
+
+export function createInMemoryCommits() {
+  return createInMemoryStore<Record<string, unknown>>();
+}
+
+export function createInMemoryMerges() {
+  const store = createInMemoryStore<Record<string, unknown>>();
+  // merges インターフェースは put のみ使う
+  return { put: store.put.bind(store), _records: store._records };
+}
+
+export function createInMemoryNodes() {
+  return createInMemoryStore<Record<string, unknown>>();
+}
+
+export function createInMemoryEdges() {
+  return createInMemoryStore<Record<string, unknown>>();
+}
+
+export function createInMemoryNodeLayouts() {
+  return createInMemoryStore<Record<string, unknown>>();
+}
+
+export function createInMemoryEdgeLayouts() {
+  return createInMemoryStore<Record<string, unknown>>();
+}
+
+export function createInMemorySheets() {
+  const store = createInMemoryStore<Record<string, unknown>>();
+  // sheets インターフェースは get のみ使う
+  return { get: store.get.bind(store), _records: store._records };
+}
+
+import type { BranchStateDeps } from '../collectionTypes';
+
+export function createInMemoryDeps(
+  overrides?: Partial<BranchStateDeps>,
+): BranchStateDeps {
+  return {
+    branches: createInMemoryBranches() as BranchStateDeps['branches'],
+    commits: createInMemoryCommits() as BranchStateDeps['commits'],
+    merges: createInMemoryMerges() as BranchStateDeps['merges'],
+    nodes: createInMemoryNodes() as BranchStateDeps['nodes'],
+    edges: createInMemoryEdges() as BranchStateDeps['edges'],
+    nodeLayouts: createInMemoryNodeLayouts() as BranchStateDeps['nodeLayouts'],
+    edgeLayouts: createInMemoryEdgeLayouts() as BranchStateDeps['edgeLayouts'],
+    sheets: createInMemorySheets() as BranchStateDeps['sheets'],
+    ...overrides,
+  };
+}

--- a/src/client/src/events/applyEvent.test.md
+++ b/src/client/src/events/applyEvent.test.md
@@ -1,0 +1,35 @@
+# applyEvent.test.ts — テスト仕様
+
+## 何をテストするか
+
+`applyEvent.ts` の `applyEvent(event, nodes, edges)` 関数。
+GraphEvent を React Flow のノード/エッジ配列に適用した結果を返す。
+
+## なぜテストするか
+
+- undo/redo の中核であり、誤ったイベント適用はグラフ状態の破壊につながる
+- structure/content/layout/presentation の4カテゴリにまたがる多様なイベント型が存在する
+- 純粋関数なのでテストが容易
+
+## どのようにテストするか
+
+| カテゴリ | テスト内容 |
+|---------|-----------|
+| NODE_ADDED | ノード追加・座標反映・エッジ非影響 |
+| NODE_DELETED | ノード削除・接続エッジ同時削除・無関係エッジ維持 |
+| EDGE_ADDED | エッジ追加・markerEnd 自動付与 |
+| EDGE_DELETED | エッジ削除・ノード非影響 |
+| EDGE_RECONNECTED | source/target 変更・labelOffset リセット |
+| NODES_GROUPED | 親ノード挿入・子ノード parentId/position 更新 |
+| NODES_UNGROUPED | 親削除・子ノード位置復元・parentId 解除 |
+| NODES_PASTED | 既存選択解除・新規追加 |
+| NODES_PASTED_UNDO | 指定 ID のノード/エッジ一括削除 |
+| NODE_RELABELED | data.label 更新 |
+| EDGE_RELABELED | label 更新 |
+| NODE_PROPERTIES_CHANGED | 未実装のため無変更確認 |
+| NODE_MOVED | position 更新 |
+| NODE_RESIZED | style.width/height 更新 |
+| EDGE_STYLE_CHANGED | data に style マージ・既存 data 保持 |
+| NODE_STYLE_CHANGED | style にマージ・既存 style 保持 |
+| EDGE_LABEL_MOVED | labelOffsetX/Y 更新 |
+| round-trip | apply → invert → apply で元の状態に戻ること |

--- a/src/client/src/events/invertEvent.test.md
+++ b/src/client/src/events/invertEvent.test.md
@@ -1,0 +1,27 @@
+# invertEvent.test.ts — テスト仕様
+
+## 何をテストするか
+
+`invertEvent.ts` の `invertEvent(event)` 関数。
+GraphEvent をその逆操作（undo用）に変換する。
+
+## なぜテストするか
+
+- undo 機能の正しさは invert → apply のラウンドトリップで保証される
+- すべてのイベント型に逆操作が定義されている必要がある
+- 二重反転対称性 `invertEvent(invertEvent(e)).type === e.type` が成立することは undo/redo スタックの健全性に直結する
+
+## どのようにテストするか
+
+| カテゴリ | テスト内容 |
+|---------|-----------|
+| NODE_ADDED ↔ NODE_DELETED | 相互変換・二重反転 |
+| EDGE_ADDED ↔ EDGE_DELETED | 相互変換・data 保持 |
+| EDGE_RECONNECTED | from/to 入れ替え |
+| NODES_GROUPED ↔ NODES_UNGROUPED | 相互変換・children 保持 |
+| NODES_PASTED ↔ NODES_PASTED_UNDO | 相互変換・nodeIds/edgeIds 収集・redo 用 data 保持 |
+| NODE_RELABELED / EDGE_RELABELED | from/to 入れ替え |
+| NODE_MOVED / NODE_RESIZED | from/to 入れ替え |
+| EDGE_STYLE_CHANGED / NODE_STYLE_CHANGED | from/to 入れ替え |
+| EDGE_LABEL_MOVED | from/to 入れ替え |
+| 二重反転対称性 | 全イベント型で type が保存されることの網羅テスト |


### PR DESCRIPTION
## Summary
- `collectionTypes.ts`: collection のインターフェース (`BranchStateDeps`) を定義
- `testing/inMemoryCollections.ts`: テスト用の in-memory collection 実装を追加
- `branchState.ts`: 全非同期関数に `deps` パラメータを追加。デフォルト引数で既存の呼び出し側に影響なし
- `branchState.test.ts` / `.test.md`: in-memory deps を使った `fetchBranchesForSheet` / `fetchCommitsForBranch` のテストを追加

## Test plan
- [x] `bun test` 全 215 tests pass
- [x] `bun run lint` pass
- [x] typecheck pass
- [x] 既存の App.tsx など呼び出し側の変更なし（デフォルト引数による後方互換）

## 依存
- #83 のブランチから派生 (#83 のテスト追加を含む)

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)