### PR TITLE
fix: コードレビュー指摘の修正 (CRITICAL 2件 + MEDIUM 3件)

### DIFF
--- a/src/client/src/AlertDialog.tsx
+++ b/src/client/src/AlertDialog.tsx
@@ -43,7 +43,9 @@ export function AlertDialog({ message, onClose, closeLabel = 'OK' }: Props) {
           boxShadow: '0 4px 24px rgba(0,0,0,0.2)',
         }}
         onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') onClose();
+        }}
       >
         <p
           style={{

--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -68,7 +68,12 @@ export default function App() {
         }
       }, AUTOSAVE_DELAY);
     },
-    [fileOps, branchOps.activeBranch],
+    [
+      fileOps.setActiveFile,
+      fileOps.persistFile,
+      fileOps.activeSheetId,
+      branchOps.activeBranch,
+    ],
   );
 
   const handleSelectSheet = useCallback(

--- a/src/client/src/ConfirmDialog.tsx
+++ b/src/client/src/ConfirmDialog.tsx
@@ -51,7 +51,9 @@ export function ConfirmDialog({
           boxShadow: '0 4px 24px rgba(0,0,0,0.2)',
         }}
         onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') onCancel();
+        }}
       >
         <p
           style={{

--- a/src/client/src/InputDialog.tsx
+++ b/src/client/src/InputDialog.tsx
@@ -61,7 +61,9 @@ export function InputDialog({
           boxShadow: '0 4px 24px rgba(0,0,0,0.2)',
         }}
         onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') onCancel();
+        }}
       >
         <label
           htmlFor="input-dialog-field"

--- a/src/client/src/hooks/useFileSheetOperations.ts
+++ b/src/client/src/hooks/useFileSheetOperations.ts
@@ -74,7 +74,9 @@ export function useFileSheetOperations({
       let file: GraphFile;
       try {
         file = await fetchFileFromAtproto(id);
-        saveFile(file).catch(() => {});
+        saveFile(file).catch((err) =>
+          console.warn('[cache] save failed:', err),
+        );
       } catch {
         file = await fetchFile(id);
       }

--- a/src/client/src/hooks/useFileSheetOperations.ts
+++ b/src/client/src/hooks/useFileSheetOperations.ts
@@ -88,18 +88,20 @@ export function useFileSheetOperations({
 
   const toggleExpand = useCallback(
     (id: string) => {
+      let isExpanding = false;
       setExpandedFileIds((prev) => {
         const next = new Set(prev);
         if (next.has(id)) {
           next.delete(id);
         } else {
           next.add(id);
-          if (!activeFile || activeFile.id !== id) {
-            openFile(id);
-          }
+          isExpanding = true;
         }
         return next;
       });
+      if (isExpanding && (!activeFile || activeFile.id !== id)) {
+        openFile(id);
+      }
     },
     [activeFile, openFile],
   );

--- a/src/client/src/hooks/useFileSheetOperations.ts
+++ b/src/client/src/hooks/useFileSheetOperations.ts
@@ -69,24 +69,33 @@ export function useFileSheetOperations({
     [activeFile, activeSheetId],
   );
 
-  const openFile = useCallback(async (id: string) => {
-    try {
-      let file: GraphFile;
+  const openFile = useCallback(
+    async (id: string) => {
       try {
-        file = await fetchFileFromAtproto(id);
-        saveFile(file).catch((err) =>
-          console.warn('[cache] save failed:', err),
-        );
-      } catch {
-        file = await fetchFile(id);
+        let file: GraphFile;
+        try {
+          file = await fetchFileFromAtproto(id);
+          saveFile(file).catch((err) =>
+            console.warn('[cache] save failed:', err),
+          );
+        } catch {
+          file = await fetchFile(id);
+        }
+        setActiveFile(file);
+        setActiveSheetId((file.sheets[0]?.id ?? null) as SheetId | null);
+        setExpandedFileIds((prev) => new Set([...prev, id]));
+      } catch (err) {
+        console.error('Failed to open file:', err);
+        await new Promise<void>((resolve) => {
+          setAlertState({
+            message: 'ファイルを開けませんでした。',
+            resolve,
+          });
+        });
       }
-      setActiveFile(file);
-      setActiveSheetId((file.sheets[0]?.id ?? null) as SheetId | null);
-      setExpandedFileIds((prev) => new Set([...prev, id]));
-    } catch (err) {
-      console.error('Failed to open file:', err);
-    }
-  }, []);
+    },
+    [setAlertState],
+  );
 
   const toggleExpand = useCallback(
     (id: string) => {


### PR DESCRIPTION
## Summary

architect + code-reviewer によるクロスレビューの指摘事項を修正。

### CRITICAL 修正

| Commit | 内容 |
|--------|------|
| a269274 | **toggleExpand**: setState updater 内で `openFile()` を呼んでいた副作用を外部に移動 |
| 1277c1e | **Escape キー**: 3 ダイアログの内側 div で `stopPropagation()` していたのを修正 |

### MEDIUM 修正

| Commit | 内容 |
|--------|------|
| b61c06b | **handleChange 依存配列**: `fileOps` 全体 → 個別の値に絞り込み (不要な再生成防止) |
| 2290bd8 | **saveFile エラーログ**: `catch(() => {})` でサイレント無視 → `console.warn` |
| 21407c3 | **openFile エラーフィードバック**: `console.error` のみ → AlertDialog でユーザーに通知 |

## 見送った項目

- HIGH: テストスペックと実テストの乖離 → Issue #92 で対応予定
- HIGH: フォーカストラップ → アクセシビリティ改善として別途対応
- MEDIUM: DRY (ModalDialog 抽出) → コンポーネント再設計時に実施

## Test plan

- [x] `bun test` — 269 pass / 0 fail
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)