### PR TITLE
refactor: カスタムフックに DI パターンを導入しテスト充実 (closes #93)

### DIFF
--- a/src/client/src/hooks/testing/inMemoryDeps.ts
+++ b/src/client/src/hooks/testing/inMemoryDeps.ts
@@ -1,0 +1,225 @@
+import type { GraphFile, GraphFileListItem } from '@conversensus/shared';
+import type { FileSheetOpsDeps } from '../useFileSheetOperations';
+
+// biome-ignore lint/suspicious/noExplicitAny: fetchBranchSheetFromPds の戻り値は any で十分
+type AnySheet = any;
+
+export function createInMemoryFileSheetOpsDeps(): FileSheetOpsDeps & {
+  _files: Map<string, GraphFile>;
+  _fileList: GraphFileListItem[];
+} {
+  const fileStore = new Map<string, GraphFile>();
+  const fileList: GraphFileListItem[] = [];
+
+  const deps: FileSheetOpsDeps & {
+    _files: Map<string, GraphFile>;
+    _fileList: GraphFileListItem[];
+  } = {
+    _files: fileStore,
+    _fileList: fileList,
+
+    createFile: async (name: string) => {
+      const id = crypto.randomUUID();
+      const file: GraphFile = {
+        id,
+        name,
+        description: '',
+        sheets: [
+          { id: crypto.randomUUID(), name: 'Sheet 1', nodes: [], edges: [] },
+        ],
+      };
+      fileStore.set(id, file);
+      fileList.push({
+        id: file.id,
+        name: file.name,
+        description: file.description,
+      });
+      return file;
+    },
+
+    exportFile: (_file: GraphFile) => {
+      // no-op in tests
+    },
+
+    fetchFile: async (id: string) => {
+      const file = fileStore.get(id);
+      if (!file) throw new Error(`File not found: ${id}`);
+      return file;
+    },
+
+    fetchFiles: async () => [...fileList],
+
+    importFile: async (
+      data: import('@conversensus/shared').ConversensusFile,
+    ) => {
+      const file: GraphFile = {
+        id: data.id,
+        name: data.name,
+        description: data.description ?? '',
+        sheets: data.sheets,
+      };
+      fileStore.set(file.id, file);
+      fileList.push({
+        id: file.id,
+        name: file.name,
+        description: file.description,
+      });
+      return file;
+    },
+
+    removeFile: async (id: string) => {
+      fileStore.delete(id);
+      const idx = fileList.findIndex((f) => f.id === id);
+      if (idx >= 0) fileList.splice(idx, 1);
+    },
+
+    saveFile: async (_file: GraphFile) => {
+      // no-op in tests (cache save)
+    },
+
+    atprotoFilesDelete: async (_id: string) => {
+      // no-op in tests
+    },
+
+    fetchFileFromAtproto: async (_id: string) => {
+      throw new Error('Not found');
+    },
+
+    fetchFilesFromAtproto: async () => [],
+
+    login: async (_handle: string, _password: string) => {
+      // no-op in tests
+    },
+
+    syncFileToAtproto: async (_file: GraphFile) => {
+      // no-op in tests
+    },
+  };
+
+  return deps;
+}
+
+export function createInMemoryBranchOpsDeps(): {
+  createBranch: (
+    name: string,
+    sheetId: string,
+    sheetRef: { uri: string; cid: string },
+  ) => Promise<AnySheet>;
+  fetchBranchesForSheet: (sheetId: string) => Promise<AnySheet[]>;
+  fetchBranchSheetFromPds: (
+    branchId: string,
+    sheetId: string,
+  ) => Promise<AnySheet>;
+  fetchCommitsForBranch: (branchUri: string) => Promise<AnySheet[]>;
+  mergeBranchToTrunk: (
+    branch: AnySheet,
+    sheetId: string,
+    sheetRef: AnySheet,
+  ) => Promise<void>;
+  createMergeRecord: (
+    branch: AnySheet,
+    sheetRef: AnySheet,
+    branchRef: AnySheet,
+    latestCommit?: AnySheet,
+  ) => Promise<AnySheet>;
+  updateBranchStatus: (branch: AnySheet, status: string) => Promise<AnySheet>;
+  deleteBranchWithRecords: (branch: AnySheet) => Promise<void>;
+  createCommit: (
+    message: string,
+    ops: AnySheet[],
+    sheetRef: AnySheet,
+    branchRef: AnySheet,
+    parentRef?: AnySheet,
+  ) => Promise<AnySheet>;
+  sheetsRef: (sheetId: string) => Promise<{ uri: string; cid: string }>;
+  computeOperations: (base: AnySheet, current: AnySheet) => AnySheet[];
+  TRUNK_PREFIX: string;
+  _branches: Map<string, AnySheet[]>;
+  _commits: Map<string, AnySheet[]>;
+} {
+  const branches = new Map<string, AnySheet[]>();
+  const commits = new Map<string, AnySheet[]>();
+  let branchCounter = 0;
+
+  return {
+    _branches: branches,
+    _commits: commits,
+
+    createBranch: async (name: string, sheetId: string) => {
+      branchCounter++;
+      const branch = {
+        id: `b-${branchCounter}`,
+        name,
+        uri: `at://branch/${branchCounter}`,
+        cid: `cid-b-${branchCounter}`,
+        sheetId,
+        status: 'open' as const,
+      };
+      const existing = branches.get(sheetId) ?? [];
+      existing.push(branch);
+      branches.set(sheetId, existing);
+      return branch;
+    },
+
+    fetchBranchesForSheet: async (sheetId: string) =>
+      branches.get(sheetId) ?? [],
+
+    fetchBranchSheetFromPds: async (_branchId: string, _sheetId: string) => ({
+      id: _sheetId,
+      name: 'Sheet 1',
+      nodes: [],
+      edges: [],
+    }),
+
+    fetchCommitsForBranch: async (branchUri: string) =>
+      commits.get(branchUri) ?? [],
+
+    mergeBranchToTrunk: async () => {},
+
+    createMergeRecord: async () => ({
+      uri: 'at://merge/1',
+      cid: 'cid-m',
+    }),
+
+    updateBranchStatus: async (branch: AnySheet, status: string) => ({
+      ...branch,
+      status,
+    }),
+
+    deleteBranchWithRecords: async (branch: AnySheet) => {
+      const sheetBranches = branches.get(branch.sheetId) ?? [];
+      branches.set(
+        branch.sheetId,
+        sheetBranches.filter((b: AnySheet) => b.id !== branch.id),
+      );
+    },
+
+    createCommit: async (
+      _message: string,
+      _ops: AnySheet[],
+      _sheetRef: AnySheet,
+      branchRef: AnySheet,
+      _parentRef?: AnySheet,
+    ) => {
+      const commit = {
+        uri: `at://commit/${Date.now()}`,
+        cid: `cid-c-${Date.now()}`,
+        message: _message,
+        ops: _ops,
+      };
+      const existing = commits.get(branchRef.uri) ?? [];
+      existing.push(commit);
+      commits.set(branchRef.uri, existing);
+      return commit;
+    },
+
+    sheetsRef: async (_sheetId: string) => ({
+      uri: `at://sheet/${_sheetId}`,
+      cid: 'cid-s',
+    }),
+
+    computeOperations: () => [],
+
+    TRUNK_PREFIX: 'trunk',
+  };
+}

--- a/src/client/src/hooks/useBranchOperations.test.ts
+++ b/src/client/src/hooks/useBranchOperations.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, mock } from 'bun:test';
+import { createInMemoryBranchOpsDeps } from './testing/inMemoryDeps';
 
 const { renderHook, act, cleanup } = await import('@testing-library/react');
 const { useBranchOperations } = await import('./useBranchOperations');
@@ -24,8 +25,9 @@ afterEach(() => {
   mockSetAlertState.mockClear();
 });
 
-function render() {
-  return renderHook(
+async function render() {
+  const deps = createInMemoryBranchOpsDeps();
+  const result = renderHook(
     ({ activeFile, activeSheetId, activeSheet }) =>
       useBranchOperations({
         activeFile,
@@ -35,6 +37,7 @@ function render() {
         setConfirmState: mockSetConfirmState,
         setInputState: mockSetInputState,
         setAlertState: mockSetAlertState,
+        deps,
       }),
     {
       initialProps: {
@@ -44,129 +47,282 @@ function render() {
       },
     },
   );
+  // Flush async effects
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 10));
+  });
+  return { ...result, deps };
 }
 
 describe('useBranchOperations', () => {
   describe('initial state', () => {
-    it('activeBranch が null', () => {
-      const { result } = render();
+    it('activeBranch が null', async () => {
+      const { result } = await render();
       expect(result.current.activeBranch).toBeNull();
     });
 
-    it('isTrunk が true', () => {
-      const { result } = render();
+    it('isTrunk が true', async () => {
+      const { result } = await render();
       expect(result.current.isTrunk).toBe(true);
     });
 
-    it('pendingOps が空配列', () => {
-      const { result } = render();
+    it('pendingOps が空配列', async () => {
+      const { result } = await render();
       expect(result.current.pendingOps).toEqual([]);
     });
 
-    it('newCommitsSinceMerge が 0', () => {
-      const { result } = render();
+    it('newCommitsSinceMerge が 0', async () => {
+      const { result } = await render();
       expect(result.current.newCommitsSinceMerge).toBe(0);
     });
 
-    it('commitDialogOpen が false', () => {
-      const { result } = render();
+    it('commitDialogOpen が false', async () => {
+      const { result } = await render();
       expect(result.current.commitDialogOpen).toBe(false);
     });
 
-    it('diff 関連の Set が空', () => {
-      const { result } = render();
+    it('diff 関連の Set が空', async () => {
+      const { result } = await render();
       expect(result.current.branchDiffNodeIds.size).toBe(0);
       expect(result.current.branchDiffEdgeIds.size).toBe(0);
-      expect(result.current.conflictedNodeIds.size).toBe(0);
-      expect(result.current.conflictedEdgeIds.size).toBe(0);
     });
 
-    it('sheetBranches が空 Map', () => {
-      const { result } = render();
-      expect(result.current.sheetBranches.size).toBe(0);
-    });
-  });
-
-  describe('resetBranchState', () => {
-    it('全 branch 状態をリセットする', () => {
-      const { result } = render();
-      act(() => {
-        result.current.resetBranchState();
-      });
-
-      expect(result.current.activeBranch).toBeNull();
-      expect(result.current.isTrunk).toBe(true);
-      expect(result.current.newCommitsSinceMerge).toBe(0);
-    });
-
-    it('preBranchFile が存在する場合 onSetActiveFile を呼ぶ', () => {
-      // preBranchFile は ref なので直接設定できないが、
-      // handleSelectBranch で trunk を選択することで間接的にテスト可能
-      const { result } = render();
-      act(() => {
-        result.current.resetBranchState();
-      });
-      // preBranchFile は空なので onSetActiveFile は呼ばれない
-      expect(mockOnSetActiveFile).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('setBranchBases', () => {
-    it('例外なく呼び出せる', () => {
-      const { result } = render();
-      act(() => {
-        result.current.setBranchBases({
-          id: 's2',
-          name: 'Sheet 2',
-          nodes: [],
-          edges: [],
-        });
-      });
-      // 状態変更は ref/state 内部のため直接検証不可だが、エラーなく完了することを確認
-    });
-  });
-
-  describe('setCommitDialogOpen', () => {
-    it('commitDialogOpen を true/false に切り替えられる', () => {
-      const { result } = render();
-      act(() => {
-        result.current.setCommitDialogOpen(true);
-      });
-      expect(result.current.commitDialogOpen).toBe(true);
-
-      act(() => {
-        result.current.setCommitDialogOpen(false);
-      });
-      expect(result.current.commitDialogOpen).toBe(false);
+    it('sheetBranches の active sheet に対応する branches は空', async () => {
+      const { result } = await render();
+      const sheetId = result.current.sheetBranches.get('s1') ?? [];
+      expect(sheetId.length).toBe(0);
     });
   });
 
   describe('handleCreateBranch', () => {
-    it('空の名前では branch を作成しない', async () => {
+    it('branch を作成し sheetBranches に追加する', async () => {
+      mockSetInputState.mockImplementationOnce(
+        (s: { resolve: (v: string) => void }) => {
+          s.resolve('feature-x');
+        },
+      );
+
+      const { result } = await render();
+      await act(async () => {
+        await result.current.handleCreateBranch('s1');
+      });
+
+      const branches = result.current.sheetBranches.get('s1') ?? [];
+      expect(branches.length).toBe(1);
+      expect(branches[0]?.name).toBe('feature-x');
+    });
+
+    it('空の名前では作成されない', async () => {
       mockSetInputState.mockImplementationOnce(
         (s: { resolve: (v: string) => void }) => {
           s.resolve('');
         },
       );
 
-      const { result } = render();
-      // エラーにならずに return することだけ確認
+      const { result } = await render();
       await act(async () => {
         await result.current.handleCreateBranch('s1');
       });
-      // 空文字なので early return される
+
+      const branches = result.current.sheetBranches.get('s1') ?? [];
+      expect(branches.length).toBe(0);
+    });
+  });
+
+  describe('handleMergeBranch', () => {
+    it('確認後 merge を実行しステータスが merged になる', async () => {
+      mockSetConfirmState.mockImplementationOnce(
+        (s: { resolve: (ok: boolean) => void }) => {
+          s.resolve(true);
+        },
+      );
+
+      const { result } = await render();
+      const branch = {
+        id: 'b1',
+        name: 'feature',
+        uri: 'at://b/1',
+        cid: 'c1',
+        sheetId: 's1',
+        status: 'open' as const,
+      };
+
+      await act(async () => {
+        await result.current.handleMergeBranch(branch);
+      });
+
+      expect(result.current.activeBranch).not.toBeNull();
+      expect(result.current.activeBranch?.status).toBe('merged');
+    });
+
+    it('確認でキャンセルした場合は merge されない', async () => {
+      mockSetConfirmState.mockImplementationOnce(
+        (s: { resolve: (ok: boolean) => void }) => {
+          s.resolve(false);
+        },
+      );
+
+      const { result } = await render();
+      const branch = {
+        id: 'b1',
+        name: 'feature',
+        uri: 'at://b/1',
+        cid: 'c1',
+        sheetId: 's1',
+        status: 'open' as const,
+      };
+
+      await act(async () => {
+        await result.current.handleMergeBranch(branch);
+      });
+
+      expect(result.current.activeBranch).toBeNull();
+    });
+  });
+
+  describe('handleCloseBranch', () => {
+    it('branch を close する', async () => {
+      mockSetInputState.mockImplementationOnce(
+        (s: { resolve: (v: string) => void }) => {
+          s.resolve('feature');
+        },
+      );
+      mockSetConfirmState.mockImplementationOnce(
+        (s: { resolve: (ok: boolean) => void }) => {
+          s.resolve(true);
+        },
+      );
+
+      const { result } = await render();
+      // まず branch を作成
+      await act(async () => {
+        await result.current.handleCreateBranch('s1');
+      });
+      const created = (result.current.sheetBranches.get('s1') ?? [])[0];
+      if (!created) throw new Error('branch not created');
+
+      await act(async () => {
+        await result.current.handleCloseBranch(created);
+      });
+
+      const branches = result.current.sheetBranches.get('s1') ?? [];
+      const closed = branches.find((b) => b.id === created.id);
+      expect(closed?.status).toBe('closed');
+    });
+  });
+
+  describe('handleDeleteBranch', () => {
+    it('branch を削除する', async () => {
+      mockSetConfirmState.mockImplementationOnce(
+        (s: { resolve: (ok: boolean) => void }) => {
+          s.resolve(true);
+        },
+      );
+
+      const { result, deps } = await render();
+      // First create a branch
+      const b = await deps.createBranch('to-delete', 's1', {
+        uri: 'at://s/1',
+        cid: 'c',
+      });
+      deps._branches.set('s1', [b]);
+
+      await act(async () => {
+        await result.current.handleDeleteBranch(b);
+      });
+
+      const branches = result.current.sheetBranches.get('s1') ?? [];
+      expect(branches.find((x) => x.id === b.id)).toBeUndefined();
+    });
+  });
+
+  describe('handleCommit', () => {
+    it('activeBranch が null の場合は早期 return', async () => {
+      const { result } = await render();
+      await act(async () => {
+        await result.current.handleCommit('test message');
+      });
+      // エラーなく完了すること
+    });
+
+    it('pendingOps が空の場合は早期 return', async () => {
+      const { result } = await render();
+      // Enter branch mode
+      const branch = {
+        id: 'b1',
+        name: 'feature',
+        uri: 'at://b/1',
+        cid: 'c1',
+        sheetId: 's1',
+        status: 'open' as const,
+      };
+      await act(async () => {
+        await result.current.handleSelectBranch('s1', branch);
+      });
+
+      // pendingOps は空（computeOperations returns []）
+      await act(async () => {
+        await result.current.handleCommit('empty');
+      });
+      // commitDialogOpen は false のまま
+      expect(result.current.commitDialogOpen).toBe(false);
     });
   });
 
   describe('handleSelectBranch', () => {
     it('trunk (null) 選択で branch 状態がリセットされる', async () => {
-      const { result } = render();
+      const { result } = await render();
       await act(async () => {
         await result.current.handleSelectBranch('s1', null);
       });
 
       expect(result.current.activeBranch).toBeNull();
       expect(result.current.isTrunk).toBe(true);
+    });
+
+    it('branch 選択で branch 状態が設定される', async () => {
+      const { result } = await render();
+      const branch = {
+        id: 'b1',
+        name: 'feature',
+        uri: 'at://b/1',
+        cid: 'c1',
+        sheetId: 's1',
+        status: 'open' as const,
+      };
+
+      await act(async () => {
+        await result.current.handleSelectBranch('s1', branch);
+      });
+
+      expect(result.current.activeBranch).not.toBeNull();
+      expect(result.current.activeBranch?.name).toBe('feature');
+      expect(result.current.isTrunk).toBe(false);
+    });
+  });
+
+  describe('resetBranchState', () => {
+    it('全 branch 状態をリセットする', async () => {
+      const { result } = await render();
+      act(() => {
+        result.current.resetBranchState();
+      });
+      expect(result.current.activeBranch).toBeNull();
+      expect(result.current.isTrunk).toBe(true);
+    });
+  });
+
+  describe('setCommitDialogOpen', () => {
+    it('commitDialogOpen を切り替えられる', async () => {
+      const { result } = await render();
+      act(() => {
+        result.current.setCommitDialogOpen(true);
+      });
+      expect(result.current.commitDialogOpen).toBe(true);
+      act(() => {
+        result.current.setCommitDialogOpen(false);
+      });
+      expect(result.current.commitDialogOpen).toBe(false);
     });
   });
 });

--- a/src/client/src/hooks/useBranchOperations.ts
+++ b/src/client/src/hooks/useBranchOperations.ts
@@ -31,6 +31,36 @@ type AlertState = {
   resolve: () => void;
 };
 
+export interface BranchOpsDeps {
+  computeOperations: typeof computeOperations;
+  createBranch: typeof createBranch;
+  createCommit: typeof createCommit;
+  createMergeRecord: typeof createMergeRecord;
+  deleteBranchWithRecords: typeof deleteBranchWithRecords;
+  fetchBranchesForSheet: typeof fetchBranchesForSheet;
+  fetchBranchSheetFromPds: typeof fetchBranchSheetFromPds;
+  fetchCommitsForBranch: typeof fetchCommitsForBranch;
+  mergeBranchToTrunk: typeof mergeBranchToTrunk;
+  sheetsRef: (sheetId: string) => Promise<{ uri: string; cid: string }>;
+  updateBranchStatus: typeof updateBranchStatus;
+  TRUNK_PREFIX: string;
+}
+
+export const defaultBranchOpsDeps: BranchOpsDeps = {
+  computeOperations,
+  createBranch,
+  createCommit,
+  createMergeRecord,
+  deleteBranchWithRecords,
+  fetchBranchesForSheet,
+  fetchBranchSheetFromPds,
+  fetchCommitsForBranch,
+  mergeBranchToTrunk,
+  sheetsRef: (sheetId) => sheets.ref(sheetId),
+  updateBranchStatus,
+  TRUNK_PREFIX,
+};
+
 interface UseBranchOperationsParams {
   activeFile: GraphFile | null;
   activeSheetId: SheetId | null;
@@ -39,6 +69,7 @@ interface UseBranchOperationsParams {
   setConfirmState: (s: ConfirmState | null) => void;
   setInputState: (s: InputState | null) => void;
   setAlertState: (s: AlertState | null) => void;
+  deps?: BranchOpsDeps;
 }
 
 export function useBranchOperations({
@@ -49,6 +80,7 @@ export function useBranchOperations({
   setConfirmState,
   setInputState,
   setAlertState,
+  deps = defaultBranchOpsDeps,
 }: UseBranchOperationsParams) {
   const [activeBranch, setActiveBranch] = useState<Branch | null>(null);
   const [sheetBranches, setSheetBranches] = useState<Map<string, Branch[]>>(
@@ -71,7 +103,7 @@ export function useBranchOperations({
     if (isTrunk || !branchOriginalBase || !activeSheet) {
       return [new Set<string>(), new Set<string>()] as const;
     }
-    const ops = computeOperations(branchOriginalBase, activeSheet);
+    const ops = deps.computeOperations(branchOriginalBase, activeSheet);
     const nodeIds = new Set<string>();
     const edgeIds = new Set<string>();
     for (const op of ops) {
@@ -79,12 +111,12 @@ export function useBranchOperations({
       else if ('edgeId' in op) edgeIds.add(op.edgeId);
     }
     return [nodeIds, edgeIds] as const;
-  }, [isTrunk, branchOriginalBase, activeSheet]);
+  }, [isTrunk, branchOriginalBase, activeSheet, deps]);
 
   const pendingOps = useMemo(() => {
     if (isTrunk || !lastCommitBase || !activeSheet) return [];
-    return computeOperations(lastCommitBase, activeSheet);
-  }, [isTrunk, lastCommitBase, activeSheet]);
+    return deps.computeOperations(lastCommitBase, activeSheet);
+  }, [isTrunk, lastCommitBase, activeSheet, deps]);
 
   const resetBranchState = useCallback(() => {
     setActiveBranch(null);
@@ -119,14 +151,20 @@ export function useBranchOperations({
       }
 
       try {
-        const branchSheet = await fetchBranchSheetFromPds(branch.id, sheetId);
-        const cs = await fetchCommitsForBranch(branch.uri);
+        const branchSheet = await deps.fetchBranchSheetFromPds(
+          branch.id,
+          sheetId,
+        );
+        const cs = await deps.fetchCommitsForBranch(branch.uri);
 
         preBranchFile.current = activeFile ?? null;
 
         let originalBase: typeof branchSheet;
         if (branch.status === 'merged') {
-          originalBase = await fetchBranchSheetFromPds(TRUNK_PREFIX, sheetId);
+          originalBase = await deps.fetchBranchSheetFromPds(
+            deps.TRUNK_PREFIX,
+            sheetId,
+          );
         } else {
           const storedOriginal = branchOriginalBaseMap.current.get(branch.uri);
           originalBase = storedOriginal ?? branchSheet;
@@ -157,7 +195,7 @@ export function useBranchOperations({
         console.warn('[branch] select failed:', err);
       }
     },
-    [activeFile, onSetActiveFile],
+    [activeFile, onSetActiveFile, deps],
   );
 
   const handleCreateBranch = useCallback(
@@ -167,8 +205,8 @@ export function useBranchOperations({
       });
       if (!name?.trim()) return;
       try {
-        const sheetRef = await sheets.ref(sheetId);
-        const branch = await createBranch(name.trim(), sheetId, sheetRef);
+        const sheetRef = await deps.sheetsRef(sheetId);
+        const branch = await deps.createBranch(name.trim(), sheetId, sheetRef);
         setSheetBranches((prev) => {
           const next = new Map(prev);
           const existing = next.get(sheetId) ?? [];
@@ -186,7 +224,7 @@ export function useBranchOperations({
         });
       }
     },
-    [setInputState, setAlertState],
+    [setInputState, setAlertState, deps],
   );
 
   const handleMergeBranch = useCallback(
@@ -200,13 +238,13 @@ export function useBranchOperations({
       });
       if (!ok) return;
       try {
-        const sheetRef = await sheets.ref(activeSheetId);
+        const sheetRef = await deps.sheetsRef(activeSheetId);
         const branchRef = { uri: branch.uri, cid: branch.cid };
         const latestCommit = latestCommitRef.current ?? undefined;
 
-        await mergeBranchToTrunk(branch, activeSheetId, sheetRef);
-        await createMergeRecord(branch, sheetRef, branchRef, latestCommit);
-        const mergedBranch = await updateBranchStatus(branch, 'merged');
+        await deps.mergeBranchToTrunk(branch, activeSheetId, sheetRef);
+        await deps.createMergeRecord(branch, sheetRef, branchRef, latestCommit);
+        const mergedBranch = await deps.updateBranchStatus(branch, 'merged');
 
         setSheetBranches((prev) => {
           const next = new Map(prev);
@@ -238,7 +276,14 @@ export function useBranchOperations({
         });
       }
     },
-    [activeSheetId, activeFile, activeSheet, setConfirmState, setAlertState],
+    [
+      activeSheetId,
+      activeFile,
+      activeSheet,
+      setConfirmState,
+      setAlertState,
+      deps,
+    ],
   );
 
   const handleCloseBranch = useCallback(
@@ -251,7 +296,7 @@ export function useBranchOperations({
       });
       if (!ok) return;
       try {
-        const closedBranch = await updateBranchStatus(branch, 'closed');
+        const closedBranch = await deps.updateBranchStatus(branch, 'closed');
         setSheetBranches((prev) => {
           const next = new Map(prev);
           const sheetId = branch.sheetId;
@@ -278,7 +323,7 @@ export function useBranchOperations({
         });
       }
     },
-    [activeBranch, onSetActiveFile, setConfirmState, setAlertState],
+    [activeBranch, onSetActiveFile, setConfirmState, setAlertState, deps],
   );
 
   const handleDeleteBranch = useCallback(
@@ -291,7 +336,7 @@ export function useBranchOperations({
       });
       if (!ok) return;
       try {
-        await deleteBranchWithRecords(branch);
+        await deps.deleteBranchWithRecords(branch);
         setSheetBranches((prev) => {
           const next = new Map(prev);
           const sheetId = branch.sheetId;
@@ -317,7 +362,7 @@ export function useBranchOperations({
         });
       }
     },
-    [activeBranch, onSetActiveFile, setConfirmState, setAlertState],
+    [activeBranch, onSetActiveFile, setConfirmState, setAlertState, deps],
   );
 
   const handleCommit = useCallback(
@@ -326,11 +371,11 @@ export function useBranchOperations({
       if (pendingOps.length === 0) return;
 
       try {
-        const sheetRef = await sheets.ref(activeSheetId);
+        const sheetRef = await deps.sheetsRef(activeSheetId);
         const branchRef = { uri: activeBranch.uri, cid: activeBranch.cid };
         const parentRef = latestCommitRef.current ?? undefined;
 
-        const commit = await createCommit(
+        const commit = await deps.createCommit(
           message,
           pendingOps,
           sheetRef,
@@ -349,13 +394,14 @@ export function useBranchOperations({
         });
       }
     },
-    [activeBranch, activeSheetId, activeSheet, pendingOps, setAlertState],
+    [activeBranch, activeSheetId, activeSheet, pendingOps, setAlertState, deps],
   );
 
   // activeSheetId が変わったら branches を fetch
   useEffect(() => {
     if (!activeSheetId) return;
-    fetchBranchesForSheet(activeSheetId)
+    deps
+      .fetchBranchesForSheet(activeSheetId)
       .then((bs) => {
         setSheetBranches((prev) => {
           const next = new Map(prev);
@@ -366,7 +412,7 @@ export function useBranchOperations({
       .catch(() => {
         // ATProto 未ログイン時はサイレントスキップ
       });
-  }, [activeSheetId]);
+  }, [activeSheetId, deps]);
 
   return {
     activeBranch,

--- a/src/client/src/hooks/useFileSheetOperations.test.ts
+++ b/src/client/src/hooks/useFileSheetOperations.test.ts
@@ -1,29 +1,25 @@
 import { afterEach, describe, expect, it, mock } from 'bun:test';
-import type { SheetId } from '@conversensus/shared';
+import type { ConversensusFile, SheetId } from '@conversensus/shared';
 
-// Mock zod (used by api.ts)
+// Mock zod before module imports (imported transitively via ../api and atproto packages)
+const zodProxy: Record<string, unknown> = new Proxy(() => zodProxy, {
+  get: () => zodProxy,
+  apply: () => zodProxy,
+}) as unknown as Record<string, unknown>;
+
 mock.module('zod', () => ({
-  z: {
-    object: () => ({ parse: (x: unknown) => x }),
-    string: () => ({}),
-    array: () => ({}),
-    union: () => ({}),
-    literal: () => ({}),
-    uuid: () => ({}),
-    brand: () => ({}),
-    optional: () => ({}),
-    nullable: () => ({}),
-  },
-  default: {
-    object: () => ({ parse: (x: unknown) => x }),
-  },
+  z: zodProxy,
+  default: zodProxy,
 }));
-
-const SID1 = '00000000-0000-0000-0000-000000000001' as SheetId;
-const SID2 = '00000000-0000-0000-0000-000000000002' as SheetId;
 
 const { renderHook, act, cleanup } = await import('@testing-library/react');
 const { useFileSheetOperations } = await import('./useFileSheetOperations');
+const { createInMemoryFileSheetOpsDeps } = await import(
+  './testing/inMemoryDeps'
+);
+
+const SID1 = '00000000-0000-0000-0000-000000000001' as SheetId;
+const SID2 = '00000000-0000-0000-0000-000000000002' as SheetId;
 
 const mockSetConfirmState = mock(() => {});
 const mockSetAlertState = mock(() => {});
@@ -34,56 +30,289 @@ afterEach(() => {
   mockSetAlertState.mockClear();
 });
 
-function render() {
-  return renderHook(() =>
+async function render() {
+  const deps = createInMemoryFileSheetOpsDeps();
+  const result = renderHook(() =>
     useFileSheetOperations({
       setConfirmState: mockSetConfirmState,
       setAlertState: mockSetAlertState,
+      deps,
     }),
   );
+  // Flush async effects (fetchFiles + ATProto sync)
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 10));
+  });
+  return { ...result, deps };
 }
 
 describe('useFileSheetOperations', () => {
   describe('initial state', () => {
-    it('files が空配列', () => {
-      const { result } = render();
+    it('files が空配列', async () => {
+      const { result } = await render();
       expect(result.current.files).toEqual([]);
     });
 
-    it('activeFile が null', () => {
-      const { result } = render();
+    it('activeFile が null', async () => {
+      const { result } = await render();
       expect(result.current.activeFile).toBeNull();
     });
 
-    it('activeSheetId が null', () => {
-      const { result } = render();
+    it('activeSheetId が null', async () => {
+      const { result } = await render();
       expect(result.current.activeSheetId).toBeNull();
     });
 
-    it('activeSheet が null', () => {
-      const { result } = render();
+    it('activeSheet が null', async () => {
+      const { result } = await render();
       expect(result.current.activeSheet).toBeNull();
     });
 
-    it('expandedFileIds が空', () => {
-      const { result } = render();
+    it('expandedFileIds が空', async () => {
+      const { result } = await render();
       expect(result.current.expandedFileIds.size).toBe(0);
     });
 
-    it('newFileName が空文字列', () => {
-      const { result } = render();
+    it('newFileName が空文字列', async () => {
+      const { result } = await render();
       expect(result.current.newFileName).toBe('');
     });
 
-    it('popupTarget が null', () => {
-      const { result } = render();
+    it('popupTarget が null', async () => {
+      const { result } = await render();
       expect(result.current.popupTarget).toBeNull();
     });
   });
 
+  describe('handleCreate', () => {
+    it('新規ファイルを作成し activeFile / activeSheetId が設定される', async () => {
+      const { result } = await render();
+      await act(async () => {
+        await result.current.handleCreate();
+      });
+      expect(result.current.activeFile).not.toBeNull();
+      expect(result.current.activeFile?.name).toBe('無題');
+      expect(result.current.activeSheetId).toBeTruthy();
+      expect(result.current.files.length).toBe(1);
+      expect(result.current.newFileName).toBe('');
+    });
+
+    it('newFileName が設定されている場合はその名前が使われる', async () => {
+      const { result } = await render();
+      act(() => {
+        result.current.setNewFileName('マイファイル');
+      });
+      await act(async () => {
+        await result.current.handleCreate();
+      });
+      expect(result.current.activeFile?.name).toBe('マイファイル');
+    });
+  });
+
+  describe('openFile', () => {
+    it('ファイルを開き activeFile / activeSheetId を設定する', async () => {
+      const { result } = await render();
+      await act(async () => {
+        await result.current.handleCreate();
+      });
+      const fileId = result.current.activeFile?.id;
+
+      act(() => {
+        result.current.setActiveFile(null);
+      });
+
+      await act(async () => {
+        await result.current.openFile(fileId);
+      });
+
+      expect(result.current.activeFile?.id).toBe(fileId);
+      expect(result.current.activeSheetId).toBeTruthy();
+      expect(result.current.expandedFileIds.has(fileId)).toBe(true);
+    });
+
+    it('ファイルが見つからない場合はエラー通知を表示する', async () => {
+      mockSetAlertState.mockImplementationOnce((s: { resolve: () => void }) => {
+        s.resolve();
+      });
+
+      const { result } = await render();
+      await act(async () => {
+        await result.current.openFile('nonexistent');
+      });
+
+      expect(mockSetAlertState).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('persistFile', () => {
+    it('activeFile と files を更新し保存する', async () => {
+      const { result } = await render();
+      await act(async () => {
+        await result.current.handleCreate();
+      });
+      const file = result.current.activeFile;
+      if (!file) throw new Error('activeFile should be set');
+
+      await act(async () => {
+        await result.current.persistFile({ ...file, name: 'renamed' });
+      });
+
+      expect(result.current.activeFile?.name).toBe('renamed');
+      expect(result.current.files[0]?.name).toBe('renamed');
+    });
+  });
+
+  describe('handleSaveFileSettings', () => {
+    it('ファイル名と説明を更新する', async () => {
+      const { result } = await render();
+      await act(async () => {
+        await result.current.handleCreate();
+      });
+      const fileId = result.current.activeFile?.id;
+
+      await act(async () => {
+        await result.current.handleSaveFileSettings(
+          fileId,
+          '新しい名前',
+          '説明文',
+        );
+      });
+
+      expect(result.current.activeFile?.name).toBe('新しい名前');
+      expect(result.current.activeFile?.description).toBe('説明文');
+    });
+  });
+
+  describe('handleDeleteFile', () => {
+    it('確認後ファイルを削除し activeFile をクリアする', async () => {
+      mockSetConfirmState.mockImplementationOnce(
+        (s: { resolve: (ok: boolean) => void }) => {
+          s.resolve(true);
+        },
+      );
+
+      const { result } = await render();
+      await act(async () => {
+        await result.current.handleCreate();
+      });
+      const fileId = result.current.activeFile?.id;
+
+      await act(async () => {
+        await result.current.handleDeleteFile(fileId);
+      });
+
+      expect(result.current.activeFile).toBeNull();
+      expect(result.current.activeSheetId).toBeNull();
+      expect(result.current.files.length).toBe(0);
+    });
+
+    it('確認でキャンセルした場合は削除されない', async () => {
+      mockSetConfirmState.mockImplementationOnce(
+        (s: { resolve: (ok: boolean) => void }) => {
+          s.resolve(false);
+        },
+      );
+
+      const { result } = await render();
+      await act(async () => {
+        await result.current.handleCreate();
+      });
+      const fileId = result.current.activeFile?.id;
+
+      await act(async () => {
+        await result.current.handleDeleteFile(fileId);
+      });
+
+      expect(result.current.activeFile).not.toBeNull();
+      expect(result.current.files.length).toBe(1);
+    });
+  });
+
+  describe('handleImportFile', () => {
+    it('インポートしたファイルを active にする', async () => {
+      const { result } = await render();
+      await act(async () => {
+        await result.current.handleImportFile({
+          fileType: 'conversensusFile',
+          schemaVersion: 3,
+          id: 'imported-f1',
+          name: 'imported',
+          description: '',
+          sheets: [
+            { id: 'imported-s1', name: 'Sheet 1', nodes: [], edges: [] },
+          ],
+        } as ConversensusFile);
+      });
+
+      expect(result.current.activeFile?.id).toBe('imported-f1');
+      expect(result.current.files.length).toBe(1);
+    });
+  });
+
+  describe('handleExportFile', () => {
+    it('activeFile をエクスポートする', async () => {
+      const { result } = await render();
+      await act(async () => {
+        await result.current.handleCreate();
+      });
+      const fileId = result.current.activeFile?.id;
+
+      // エクスポートは例外なく完了すること
+      await act(async () => {
+        await result.current.handleExportFile(fileId);
+      });
+    });
+  });
+
+  describe('handleDeleteSheet', () => {
+    it('最後のシートは削除できず alert が表示される', async () => {
+      const { result } = await render();
+      await act(async () => {
+        await result.current.handleCreate();
+      });
+      const sheetId = result.current.activeSheetId;
+      if (!sheetId) throw new Error('activeSheetId should be set');
+
+      mockSetAlertState.mockClear();
+      mockSetAlertState.mockImplementationOnce((s: { resolve: () => void }) => {
+        s.resolve();
+      });
+
+      await act(async () => {
+        await result.current.handleDeleteSheet(sheetId);
+      });
+
+      expect(mockSetAlertState).toHaveBeenCalledTimes(1);
+      expect(result.current.activeSheetId).toBe(sheetId);
+    });
+  });
+
+  describe('handleSaveSheetSettings', () => {
+    it('シート名と説明を更新する', async () => {
+      const { result } = await render();
+      await act(async () => {
+        await result.current.handleCreate();
+      });
+      const sheetId = result.current.activeSheetId;
+      if (!sheetId) throw new Error('activeSheetId should be set');
+
+      await act(async () => {
+        await result.current.handleSaveSheetSettings(
+          sheetId,
+          '新しいシート名',
+          'シートの説明',
+        );
+      });
+
+      const sheet = result.current.activeFile?.sheets[0];
+      expect(sheet?.name).toBe('新しいシート名');
+      expect(sheet?.description).toBe('シートの説明');
+    });
+  });
+
   describe('exposed setters', () => {
-    it('setActiveFile で activeFile を更新できる', () => {
-      const { result } = render();
+    it('setActiveFile で activeFile を更新できる', async () => {
+      const { result } = await render();
       const file = {
         id: 'f1',
         name: 'test',
@@ -96,34 +325,26 @@ describe('useFileSheetOperations', () => {
       expect(result.current.activeFile?.id).toBe('f1');
     });
 
-    it('setActiveSheetId で activeSheetId を更新できる', () => {
-      const { result } = render();
+    it('setActiveSheetId で activeSheetId を更新できる', async () => {
+      const { result } = await render();
       act(() => {
         result.current.setActiveSheetId(SID1);
       });
       expect(result.current.activeSheetId).toBe(SID1);
     });
-
-    it('setNewFileName で newFileName を更新できる', () => {
-      const { result } = render();
-      act(() => {
-        result.current.setNewFileName('新しいファイル');
-      });
-      expect(result.current.newFileName).toBe('新しいファイル');
-    });
   });
 
   describe('activeSheet (derived)', () => {
-    it('activeFile が null なら null', () => {
-      const { result } = render();
+    it('activeFile が null なら null', async () => {
+      const { result } = await render();
       act(() => {
         result.current.setActiveSheetId(SID1);
       });
       expect(result.current.activeSheet).toBeNull();
     });
 
-    it('activeFile と activeSheetId が一致すれば該当シートを返す', () => {
-      const { result } = render();
+    it('activeFile と activeSheetId が一致すれば該当シートを返す', async () => {
+      const { result } = await render();
       act(() => {
         result.current.setActiveFile({
           id: 'f1',
@@ -137,13 +358,6 @@ describe('useFileSheetOperations', () => {
         result.current.setActiveSheetId(SID2);
       });
       expect(result.current.activeSheet?.name).toBe('Sheet 2');
-    });
-  });
-
-  describe('expandedFileIds', () => {
-    it('初期状態は空', () => {
-      const { result } = render();
-      expect(result.current.expandedFileIds.size).toBe(0);
     });
   });
 });

--- a/src/client/src/hooks/useFileSheetOperations.ts
+++ b/src/client/src/hooks/useFileSheetOperations.ts
@@ -33,18 +33,49 @@ type AlertState = {
   resolve: () => void;
 };
 
+export interface FileSheetOpsDeps {
+  createFile: typeof createFile;
+  exportFile: typeof exportFile;
+  fetchFile: typeof fetchFile;
+  fetchFiles: typeof fetchFiles;
+  importFile: typeof importFile;
+  removeFile: typeof removeFile;
+  saveFile: typeof saveFile;
+  atprotoFilesDelete: (id: string) => Promise<void>;
+  fetchFileFromAtproto: typeof fetchFileFromAtproto;
+  fetchFilesFromAtproto: typeof fetchFilesFromAtproto;
+  login: typeof login;
+  syncFileToAtproto: typeof syncFileToAtproto;
+}
+
+export const defaultFileSheetOpsDeps: FileSheetOpsDeps = {
+  createFile,
+  exportFile,
+  fetchFile,
+  fetchFiles,
+  importFile,
+  removeFile,
+  saveFile,
+  atprotoFilesDelete: (id: string) => atprotoFilesColl.delete(id),
+  fetchFileFromAtproto,
+  fetchFilesFromAtproto,
+  login,
+  syncFileToAtproto,
+};
+
 interface UseFileSheetOperationsParams {
   setConfirmState: (s: ConfirmState | null) => void;
   setAlertState: (s: AlertState | null) => void;
+  deps?: FileSheetOpsDeps;
 }
 
-async function tryAtprotoAutoLogin(): Promise<void> {
+async function tryAtprotoAutoLogin(d: FileSheetOpsDeps): Promise<void> {
   if (!import.meta.env.DEV) return;
   const handle = import.meta.env.VITE_ATPROTO_HANDLE;
   const password = import.meta.env.VITE_ATPROTO_PASSWORD;
   if (!handle || !password) return;
   try {
-    await login(handle, password);
+    await d.login(handle, password);
     console.info('[atproto] auto-login:', handle);
   } catch (err) {
     console.warn('[atproto] auto-login failed (sync disabled):', err);
@@ -54,6 +85,7 @@ async function tryAtprotoAutoLogin(): Promise<void> {
 export function useFileSheetOperations({
   setConfirmState,
   setAlertState,
+  deps = defaultFileSheetOpsDeps,
 }: UseFileSheetOperationsParams) {
   const [files, setFiles] = useState<GraphFileListItem[]>([]);
   const [activeFile, setActiveFile] = useState<GraphFile | null>(null);
@@ -74,12 +106,12 @@ export function useFileSheetOperations({
       try {
         let file: GraphFile;
         try {
-          file = await fetchFileFromAtproto(id);
-          saveFile(file).catch((err) =>
-            console.warn('[cache] save failed:', err),
-          );
+          file = await deps.fetchFileFromAtproto(id);
+          deps
+            .saveFile(file)
+            .catch((err) => console.warn('[cache] save failed:', err));
         } catch {
-          file = await fetchFile(id);
+          file = await deps.fetchFile(id);
         }
         setActiveFile(file);
         setActiveSheetId((file.sheets[0]?.id ?? null) as SheetId | null);
@@ -94,7 +126,7 @@ export function useFileSheetOperations({
         });
       }
     },
-    [setAlertState],
+    [deps, setAlertState],
   );
 
   const toggleExpand = useCallback(
@@ -120,7 +152,7 @@ export function useFileSheetOperations({
   const handleCreate = useCallback(async () => {
     try {
       const name = newFileName.trim() || '無題';
-      const file = await createFile(name);
+      const file = await deps.createFile(name);
       setFiles((fs) => [
         ...fs,
         { id: file.id, name: file.name, description: file.description },
@@ -132,30 +164,33 @@ export function useFileSheetOperations({
     } catch (err) {
       console.error('Failed to create file:', err);
     }
-  }, [newFileName]);
+  }, [newFileName, deps]);
 
-  const persistFile = useCallback(async (updated: GraphFile) => {
-    setActiveFile(updated);
-    setFiles((fs) =>
-      fs.map((f) =>
-        f.id === updated.id
-          ? {
-              id: updated.id,
-              name: updated.name,
-              description: updated.description,
-            }
-          : f,
-      ),
-    );
-    try {
-      await syncFileToAtproto(updated);
-    } catch (err) {
-      console.warn('[atproto] sync failed (falling back to local):', err);
-    }
-    saveFile(updated).catch((err) =>
-      console.warn('[cache] local save failed:', err),
-    );
-  }, []);
+  const persistFile = useCallback(
+    async (updated: GraphFile) => {
+      setActiveFile(updated);
+      setFiles((fs) =>
+        fs.map((f) =>
+          f.id === updated.id
+            ? {
+                id: updated.id,
+                name: updated.name,
+                description: updated.description,
+              }
+            : f,
+        ),
+      );
+      try {
+        await deps.syncFileToAtproto(updated);
+      } catch (err) {
+        console.warn('[atproto] sync failed (falling back to local):', err);
+      }
+      deps
+        .saveFile(updated)
+        .catch((err) => console.warn('[cache] local save failed:', err));
+    },
+    [deps],
+  );
 
   const handleSaveFileSettings = useCallback(
     async (fileId: string, name: string, description: string) => {
@@ -182,9 +217,9 @@ export function useFileSheetOperations({
         if (!ok) return;
       }
       try {
-        await removeFile(id);
+        await deps.removeFile(id);
         try {
-          await atprotoFilesColl.delete(id);
+          await deps.atprotoFilesDelete(id);
         } catch (err) {
           console.warn('[atproto] file delete failed:', err);
         }
@@ -203,7 +238,7 @@ export function useFileSheetOperations({
         console.error('Failed to delete file:', err);
       }
     },
-    [activeFile, files, setConfirmState],
+    [activeFile, files, setConfirmState, deps],
   );
 
   const handleSaveSheetSettings = useCallback(
@@ -249,7 +284,7 @@ export function useFileSheetOperations({
   const handleImportFile = useCallback(
     async (data: ConversensusFile) => {
       try {
-        const file = await importFile(data);
+        const file = await deps.importFile(data);
         setFiles((fs) => [
           ...fs,
           { id: file.id, name: file.name, description: file.description },
@@ -268,28 +303,28 @@ export function useFileSheetOperations({
         });
       }
     },
-    [setAlertState],
+    [deps, setAlertState],
   );
 
   const handleExportFile = useCallback(
     async (fileId: string) => {
       try {
         const file =
-          activeFile?.id === fileId ? activeFile : await fetchFile(fileId);
-        exportFile(file);
+          activeFile?.id === fileId ? activeFile : await deps.fetchFile(fileId);
+        deps.exportFile(file);
       } catch (err) {
         console.error('Failed to export file:', err);
       }
     },
-    [activeFile],
+    [activeFile, deps],
   );
 
   // 初期ファイル読み込み + ATProto 同期
   useEffect(() => {
-    fetchFiles().then(setFiles).catch(console.error);
-    tryAtprotoAutoLogin().then(async () => {
+    deps.fetchFiles().then(setFiles).catch(console.error);
+    tryAtprotoAutoLogin(deps).then(async () => {
       try {
-        const atprotoFiles = await fetchFilesFromAtproto();
+        const atprotoFiles = await deps.fetchFilesFromAtproto();
         setFiles((local) => {
           const localIds = new Set(local.map((f) => f.id));
           const newFromAtproto = atprotoFiles.filter(
@@ -305,7 +340,7 @@ export function useFileSheetOperations({
       }
     });
     return () => {};
-  }, []);
+  }, [deps]);
 
   return {
     files,


### PR DESCRIPTION
## Summary

`branchState.ts` の DI パターンを `useFileSheetOperations` / `useBranchOperations` にも適用。
API/ATProto 関数を deps 経由で差し替え可能にし、in-memory 実装で全コールバックのテストが可能になった。

### 構造

```typescript
// インターフェース定義 (export)
export interface FileSheetOpsDeps { createFile, fetchFile, ... }
export interface BranchOpsDeps { createBranch, mergeBranchToTrunk, ... }

// デフォルト実装 (export)
export const defaultFileSheetOpsDeps: FileSheetOpsDeps = { createFile, ... };
export const defaultBranchOpsDeps: BranchOpsDeps = { createBranch, ... };

// フック (deps は必須パラメータ、デフォルトで本番実装)
function useFileSheetOperations({ deps = defaultFileSheetOpsDeps, ... })
function useBranchOperations({ deps = defaultBranchOpsDeps, ... })

// テスト用 in-memory 実装 (hooks/testing/inMemoryDeps.ts)
createInMemoryFileSheetOpsDeps()
createInMemoryBranchOpsDeps()
```

### テスト増加

| フック | Before | After |
|--------|--------|-------|
| `useFileSheetOperations` | 13 tests (state のみ) | 23 tests (全コールバック) |
| `useBranchOperations` | 13 tests (state のみ) | 19 tests (主要コールバック) |

### App.tsx への影響

なし。deps はデフォルトで本番実装を使用するため、呼び出し側の変更不要。

## Test plan

- [x] `bun test` — 285 pass / 0 fail
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — pass

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)