### PR TITLE
fix: close された branch を凍結し編集・commit・merge を不可に (ANA-70)

### DIFF
--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -54,7 +54,12 @@ export default function App() {
       const sheetId = fileOps.activeSheetId;
 
       saveTimer.current = setTimeout(async () => {
-        if (branch && branch.name !== 'trunk' && sheetId) {
+        if (
+          branch &&
+          branch.name !== 'trunk' &&
+          sheetId &&
+          branch.status === 'open'
+        ) {
           const sheet = updated.sheets.find((s) => s.id === sheetId);
           if (!sheet) return;
           try {
@@ -170,7 +175,7 @@ export default function App() {
           </div>
         )}
       </main>
-      {!branchOps.isTrunk && branch && (
+      {!branchOps.isTrunk && branch && branch.status === 'open' && (
         <div
           style={{
             position: 'fixed',

--- a/src/client/src/hooks/useBranchOperations.ts
+++ b/src/client/src/hooks/useBranchOperations.ts
@@ -114,9 +114,15 @@ export function useBranchOperations({
   }, [isTrunk, branchOriginalBase, activeSheet, deps]);
 
   const pendingOps = useMemo(() => {
-    if (isTrunk || !lastCommitBase || !activeSheet) return [];
+    if (
+      isTrunk ||
+      !lastCommitBase ||
+      !activeSheet ||
+      activeBranch?.status !== 'open'
+    )
+      return [];
     return deps.computeOperations(lastCommitBase, activeSheet);
-  }, [isTrunk, lastCommitBase, activeSheet, deps]);
+  }, [isTrunk, lastCommitBase, activeSheet, activeBranch?.status, deps]);
 
   const resetBranchState = useCallback(() => {
     setActiveBranch(null);


### PR DESCRIPTION
## Summary
- close された branch では floating panel (commit/merge ボタン) を非表示
- `handleChange` で closed branch の auto-save をスキップ
- `pendingOps` を非 open branch では空配列に（commit 不可に）

## Test plan
- [x] lint / typecheck パス
- [x] 285 tests pass (0 fail)

Closes ANA-70

🤖 Generated with [Claude Code](https://claude.com/claude-code)