### PR TITLE
fix: 空 sheet から branch 作成時に PDS 未同期エラーが出る問題を修正 (ANA-69)

### DIFF
--- a/src/client/src/hooks/testing/inMemoryDeps.ts
+++ b/src/client/src/hooks/testing/inMemoryDeps.ts
@@ -132,6 +132,7 @@ export function createInMemoryBranchOpsDeps(): {
     parentRef?: AnySheet,
   ) => Promise<AnySheet>;
   sheetsRef: (sheetId: string) => Promise<{ uri: string; cid: string }>;
+  syncFileToAtproto: (file: AnySheet) => Promise<void>;
   computeOperations: (base: AnySheet, current: AnySheet) => AnySheet[];
   TRUNK_PREFIX: string;
   _branches: Map<string, AnySheet[]>;
@@ -217,6 +218,8 @@ export function createInMemoryBranchOpsDeps(): {
       uri: `at://sheet/${_sheetId}`,
       cid: 'cid-s',
     }),
+
+    syncFileToAtproto: async () => {},
 
     computeOperations: () => [],
 

--- a/src/client/src/hooks/useBranchOperations.ts
+++ b/src/client/src/hooks/useBranchOperations.ts
@@ -12,6 +12,7 @@ import {
   fetchCommitsForBranch,
   mergeBranchToTrunk,
   sheets,
+  syncFileToAtproto,
   TRUNK_PREFIX,
   updateBranchStatus,
 } from '../atproto';
@@ -43,6 +44,7 @@ export interface BranchOpsDeps {
   mergeBranchToTrunk: typeof mergeBranchToTrunk;
   sheetsRef: (sheetId: string) => Promise<{ uri: string; cid: string }>;
   updateBranchStatus: typeof updateBranchStatus;
+  syncFileToAtproto: typeof syncFileToAtproto;
   TRUNK_PREFIX: string;
 }
 
@@ -58,6 +60,7 @@ export const defaultBranchOpsDeps: BranchOpsDeps = {
   mergeBranchToTrunk,
   sheetsRef: (sheetId) => sheets.ref(sheetId),
   updateBranchStatus,
+  syncFileToAtproto,
   TRUNK_PREFIX,
 };
 
@@ -205,7 +208,14 @@ export function useBranchOperations({
       });
       if (!name?.trim()) return;
       try {
-        const sheetRef = await deps.sheetsRef(sheetId);
+        let sheetRef: { uri: string; cid: string };
+        try {
+          sheetRef = await deps.sheetsRef(sheetId);
+        } catch {
+          if (!activeFile) throw new Error('アクティブなファイルがありません');
+          await deps.syncFileToAtproto(activeFile);
+          sheetRef = await deps.sheetsRef(sheetId);
+        }
         const branch = await deps.createBranch(name.trim(), sheetId, sheetRef);
         setSheetBranches((prev) => {
           const next = new Map(prev);
@@ -224,7 +234,7 @@ export function useBranchOperations({
         });
       }
     },
-    [setInputState, setAlertState, deps],
+    [activeFile, setInputState, setAlertState, deps],
   );
 
   const handleMergeBranch = useCallback(


### PR DESCRIPTION
## Summary
- `handleCreateBranch` で `sheets.ref` が失敗した場合、先に `syncFileToAtproto` を実行してシートを PDS に同期してからリトライ
- `BranchOpsDeps` に `syncFileToAtproto` を追加

## Test plan
- [x] lint / typecheck パス
- [x] 285 tests pass (0 fail)

Closes ANA-69

🤖 Generated with [Claude Code](https://claude.com/claude-code)