### PR TITLE
fix: branch 切り替え時に undo/redo 履歴が失われる問題を修正 (ANA-72)

### DIFF
--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -6,6 +6,7 @@ import { CommitDialog } from './CommitDialog';
 import { ConfirmDialog } from './ConfirmDialog';
 import { GraphEditor } from './GraphEditor';
 import { useBranchOperations } from './hooks/useBranchOperations';
+import type { UndoState } from './hooks/useEventStore';
 import { useFileSheetOperations } from './hooks/useFileSheetOperations';
 import { InputDialog } from './InputDialog';
 import { Sidebar } from './Sidebar';
@@ -29,6 +30,7 @@ export default function App() {
   } | null>(null);
 
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const undoStateMapRef = useRef<Map<string, UndoState>>(new Map());
 
   // File & sheet operations
   const fileOps = useFileSheetOperations({ setConfirmState, setAlertState });
@@ -150,6 +152,8 @@ export default function App() {
         {fileOps.activeFile && fileOps.activeSheetId ? (
           <GraphEditor
             key={`${fileOps.activeSheetId}/${branchOps.activeBranch?.id ?? 'trunk'}`}
+            graphKey={`${fileOps.activeSheetId}/${branchOps.activeBranch?.id ?? 'trunk'}`}
+            undoStateMap={undoStateMapRef}
             file={fileOps.activeFile}
             activeSheetId={fileOps.activeSheetId}
             onChange={handleChange}

--- a/src/client/src/GraphEditor.tsx
+++ b/src/client/src/GraphEditor.tsx
@@ -48,7 +48,7 @@ import {
 } from './graphTransform';
 import { useClipboard } from './hooks/useClipboard';
 import { useEdgeContextMenu } from './hooks/useEdgeContextMenu';
-import { useEventStore } from './hooks/useEventStore';
+import { type UndoState, useEventStore } from './hooks/useEventStore';
 import { useGroupNodes } from './hooks/useGroupNodes';
 import { usePaneDoubleClick } from './hooks/usePaneDoubleClick';
 
@@ -58,6 +58,8 @@ type Props = {
   onChange: (file: GraphFile) => void;
   conflictedNodeIds?: Set<string>;
   conflictedEdgeIds?: Set<string>;
+  graphKey?: string;
+  undoStateMap?: React.MutableRefObject<Map<string, UndoState>>;
 };
 
 function GraphEditorInner({
@@ -66,6 +68,8 @@ function GraphEditorInner({
   onChange,
   conflictedNodeIds,
   conflictedEdgeIds,
+  graphKey,
+  undoStateMap,
 }: Props) {
   const { screenToFlowPosition, getNodes, getEdges } = useReactFlow();
   const activeSheet = file.sheets.find((s) => s.id === activeSheetId);
@@ -180,12 +184,21 @@ function GraphEditorInner({
   const edgeTypes = useMemo(() => ({ editableLabel: EditableLabelEdge }), []);
 
   // --- Event store ---
-  const { dispatch, undo, redo, setDragging } = useEventStore(
-    nodes,
-    edges,
-    setNodes,
-    setEdges,
-  );
+  const { dispatch, undo, redo, setDragging, exportState, importState } =
+    useEventStore(nodes, edges, setNodes, setEdges);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: mount/unmount のみ (React key 変更による再マウント)
+  useEffect(() => {
+    if (!graphKey || !undoStateMap) return;
+    const key = graphKey;
+    const saved = undoStateMap.current.get(key);
+    if (saved) {
+      importState(saved);
+    }
+    return () => {
+      undoStateMap.current.set(key, exportState());
+    };
+  }, []);
 
   // --- Node drag tracking for NODE_MOVED ---
   const preDragPositionsRef = useRef<Map<string, { x: number; y: number }>>(

--- a/src/client/src/hooks/useEventStore.ts
+++ b/src/client/src/hooks/useEventStore.ts
@@ -7,6 +7,8 @@ import { invertEvent } from '../events/invertEvent';
 
 const MAX_UNDO_STACK = 50;
 
+export type UndoState = { undoStack: GraphEvent[]; redoStack: GraphEvent[] };
+
 export function useEventStore(
   nodes: Node[],
   edges: Edge[],
@@ -20,6 +22,8 @@ export function useEventStore(
   canRedo: boolean;
   eventLog: GraphEvent[];
   setDragging: (dragging: boolean) => void;
+  exportState: () => UndoState;
+  importState: (state: UndoState | undefined) => void;
 } {
   const eventLogRef = useRef<GraphEvent[]>([]);
   const undoStackRef = useRef<GraphEvent[]>([]);
@@ -94,6 +98,22 @@ export function useEventStore(
     setCanRedo(redoStackRef.current.length > 0);
   }, [setNodes, setEdges]);
 
+  const exportState = useCallback(
+    () => ({
+      undoStack: undoStackRef.current.slice(),
+      redoStack: redoStackRef.current.slice(),
+    }),
+    [],
+  );
+
+  const importState = useCallback((state: UndoState | undefined) => {
+    if (!state) return;
+    undoStackRef.current = state.undoStack.slice();
+    redoStackRef.current = state.redoStack.slice();
+    setCanUndo(state.undoStack.length > 0);
+    setCanRedo(state.redoStack.length > 0);
+  }, []);
+
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (!(e.metaKey || e.ctrlKey)) return;
@@ -120,5 +140,7 @@ export function useEventStore(
     canRedo,
     eventLog: eventLogRef.current,
     setDragging,
+    exportState,
+    importState,
   };
 }


### PR DESCRIPTION
## Summary
- `useEventStore` に `exportState()` / `importState()` を追加
- `GraphEditor` のマウント/アンマウント時に undo/redo スタックを branch ごとに保存・復元
- `App.tsx` で `undoStateMapRef` を保持し、`graphKey` でコンテキストを識別

## Test plan
- [x] lint / typecheck パス
- [x] 285 tests pass (0 fail)

Closes ANA-72

🤖 Generated with [Claude Code](https://claude.com/claude-code)