### PR TITLE
fix: グループ手動リサイズ後に自動拡大が機能しなくなるバグを修正 (ANA-41)

### DIFF
--- a/src/client/src/graphTransform.test.ts
+++ b/src/client/src/graphTransform.test.ts
@@ -421,6 +421,32 @@ describe('recalculateParentBounds', () => {
     expect(result.find((n) => n.id === 'g1')?.position.y).toBe(60);
     expect(result.find((n) => n.id === 'n1')?.position.y).toBe(50);
   });
+
+  it('style.width より measured.width が大きい場合も正しく拡大される', () => {
+    // 手動リサイズ後: style が固定値でも measured (実際のDOMサイズ) が大きければ反映される
+    const parent: Node = {
+      id: 'g1',
+      position: { x: 0, y: 0 },
+      data: {},
+      type: 'groupNode',
+      style: { width: 200, height: 200 }, // 手動リサイズ後の固定値
+      measured: { width: 400, height: 300 }, // ReactFlow の実測値
+    };
+    const child: Node = {
+      id: 'n1',
+      parentId: 'g1',
+      position: { x: 380, y: 50 }, // x=380 + width=160 = 540 > 400
+      data: {},
+      type: 'editableNode',
+      style: { width: 160, height: 80 },
+    };
+    const result = recalculateParentBounds([parent, child]);
+    const resultParent = result.find((n) => n.id === 'g1');
+    // child right = 380 + 160 = 540, newWidth = max(200,400, 540+20) = 560
+    expect(Number(resultParent?.style?.width)).toBe(560);
+    // height: child bottom = 50 + 80 = 130 < max(200,300) = 300 → no change
+    expect(Number(resultParent?.style?.height)).toBe(300);
+  });
 });
 
 describe('toFlowEdges → fromFlowEdges の対称性', () => {

--- a/src/client/src/graphTransform.ts
+++ b/src/client/src/graphTransform.ts
@@ -120,11 +120,13 @@ export function recalculateParentBounds(nodes: Node[]): Node[] {
     const parent = nodes.find((n) => n.id === parentId);
     if (!parent) continue;
 
-    const parentWidth = Number(
-      parent.style?.width ?? parent.measured?.width ?? 0,
+    const parentWidth = Math.max(
+      Number(parent.style?.width ?? 0),
+      Number(parent.measured?.width ?? 0),
     );
-    const parentHeight = Number(
-      parent.style?.height ?? parent.measured?.height ?? 0,
+    const parentHeight = Math.max(
+      Number(parent.style?.height ?? 0),
+      Number(parent.measured?.height ?? 0),
     );
 
     const minChildX = Math.min(...children.map((c) => c.position.x));


### PR DESCRIPTION
## Summary
- `recalculateParentBounds` の親ノードサイズ取得を `Math.max(style, measured)` に変更
- 手動リサイズで `style.width/height` が固定値になった後でも、ReactFlow の実測値(`measured`)が異なる場合に正しく自動拡大が動作する

## Test plan
- [x] lint / typecheck パス
- [x] 286 tests pass (0 fail, 新規1件追加)
- [x] `style.width` より `measured.width` が大きいケースのテスト追加

Closes ANA-41

🤖 Generated with [Claude Code](https://claude.com/claude-code)