### PR TITLE
refactor: nodeType/parentId を NodeLayout から GraphNode へ移動し CommitOperation を拡張 (ANA-47)

### DIFF
--- a/src/client/src/GroupNode.tsx
+++ b/src/client/src/GroupNode.tsx
@@ -70,13 +70,13 @@ export function GroupNode({
       const graphNode: GraphNode = {
         id: nodeId,
         content: '',
+        parentId: id as NodeId,
       };
       const layout: NodeLayout = {
         nodeId,
         x: pos.x,
         y: pos.y,
         ...DEFAULT_NODE_STYLE,
-        parentId: id as NodeId,
       };
       dispatch({
         ...makeEventBase('structure'),

--- a/src/client/src/Sidebar.tsx
+++ b/src/client/src/Sidebar.tsx
@@ -3,10 +3,12 @@ import {
   ConversensusFileSchema,
   ConversensusFileV1Schema,
   ConversensusFileV2Schema,
+  ConversensusFileV3Schema,
   type GraphFile,
   type GraphFileListItem,
   migrateV1toV2,
   migrateV2toV3,
+  migrateV3toV4,
   type SheetId,
 } from '@conversensus/shared';
 import { useRef, useState } from 'react';
@@ -105,16 +107,24 @@ export function Sidebar({
           onImportFile(parsed.data);
           return;
         }
+        // v3 ファイルの場合はマイグレーションを試みる
+        const parsedV3 = ConversensusFileV3Schema.safeParse(json);
+        if (parsedV3.success) {
+          onImportFile(migrateV3toV4(parsedV3.data));
+          return;
+        }
         // v2 ファイルの場合はマイグレーションを試みる
         const parsedV2 = ConversensusFileV2Schema.safeParse(json);
         if (parsedV2.success) {
-          onImportFile(migrateV2toV3(parsedV2.data));
+          onImportFile(migrateV3toV4(migrateV2toV3(parsedV2.data)));
           return;
         }
         // v1 ファイルの場合はマイグレーションを試みる
         const parsedV1 = ConversensusFileV1Schema.safeParse(json);
         if (parsedV1.success) {
-          onImportFile(migrateV2toV3(migrateV1toV2(parsedV1.data)));
+          onImportFile(
+            migrateV3toV4(migrateV2toV3(migrateV1toV2(parsedV1.data))),
+          );
           return;
         }
         const messages = parsed.error.errors

--- a/src/client/src/atproto/branchState.ts
+++ b/src/client/src/atproto/branchState.ts
@@ -107,6 +107,8 @@ export function computeOperations(
         nodeId: node.id,
         content: node.content,
         ...(node.properties && { properties: node.properties }),
+        ...(node.nodeType && { nodeType: node.nodeType }),
+        ...(node.parentId !== undefined && { parentId: node.parentId }),
       });
     }
   }
@@ -116,13 +118,17 @@ export function computeOperations(
     if (
       baseNode &&
       (baseNode.content !== node.content ||
-        JSON.stringify(baseNode.properties) !== JSON.stringify(node.properties))
+        JSON.stringify(baseNode.properties) !==
+          JSON.stringify(node.properties) ||
+        baseNode.nodeType !== node.nodeType ||
+        baseNode.parentId !== node.parentId)
     ) {
       ops.push({
         op: 'node.update',
         nodeId: node.id,
         content: node.content,
         ...(node.properties && { properties: node.properties }),
+        ...(node.parentId !== undefined && { parentId: node.parentId }),
       });
     }
   }
@@ -295,7 +301,6 @@ type TrunkSheetData = {
   nodeLayouts: Array<{
     layout: NodeLayout;
     nodeRef: StrongRef;
-    parentRef?: StrongRef;
   }>;
   edgeLayouts: Array<{ layout: EdgeLayout; edgeRef: StrongRef }>;
 };
@@ -359,16 +364,9 @@ async function fetchTrunkSheetData(
       const rec = r.value as NodeLayoutRecord;
       const nodeId =
         nodeUriToId.get(rec.node.uri) ?? idFromRkey(rkeyFromUri(rec.node.uri));
-      const parentId = rec.parent
-        ? (nodeUriToId.get(rec.parent.uri) ??
-          idFromRkey(rkeyFromUri(rec.parent.uri)))
-        : undefined;
       return {
         layout: recordToNodeLayout(nodeId, rec),
         nodeRef: nodeIdToRef.get(nodeId) ?? rec.node,
-        parentRef: parentId
-          ? (nodeIdToRef.get(parentId) ?? rec.parent)
-          : undefined,
       };
     });
 
@@ -444,16 +442,13 @@ export async function createBranch(
   );
 
   await Promise.all(
-    trunkData.nodeLayouts.map(async ({ layout, nodeRef: _, parentRef: __ }) => {
+    trunkData.nodeLayouts.map(async ({ layout, nodeRef: _ }) => {
       const nodeRef = nodeIdToBranchRef.get(layout.nodeId);
       if (!nodeRef) return;
-      const parentRef = layout.parentId
-        ? nodeIdToBranchRef.get(layout.parentId)
-        : undefined;
       const rkey = makeRkey(branchId, layout.nodeId);
       await deps.nodeLayouts.put(
         rkey,
-        nodeLayoutToRecord(layout, nodeRef, parentRef, now),
+        nodeLayoutToRecord(layout, nodeRef, now),
       );
     }),
   );
@@ -617,13 +612,10 @@ export async function syncBranchSheetToAtproto(
       sheet.layouts.map(async (layout) => {
         const nodeRef = nodeIdToRef.get(layout.nodeId);
         if (!nodeRef) return;
-        const parentRef = layout.parentId
-          ? nodeIdToRef.get(layout.parentId)
-          : undefined;
         const rkey = makeRkey(branchId, layout.nodeId);
         await deps.nodeLayouts.put(
           rkey,
-          nodeLayoutToRecord(layout, nodeRef, parentRef, now),
+          nodeLayoutToRecord(layout, nodeRef, now),
         );
       }),
     );
@@ -802,16 +794,11 @@ export async function mergeBranchToTrunk(
         const nodeId = idFromRkey(rkeyFromUri(rec.node.uri));
         const trunkNodeRef = nodeIdToTrunkRef.get(nodeId);
         if (!trunkNodeRef) return;
-        const parentId = rec.parent
-          ? idFromRkey(rkeyFromUri(rec.parent.uri))
-          : undefined;
-        const parentRef = parentId ? nodeIdToTrunkRef.get(parentId) : undefined;
         const { $type: _, ...data } = rec;
         const trunkRkey = makeRkey(TRUNK_PREFIX, nodeId);
         await deps.nodeLayouts.put(trunkRkey, {
           ...data,
           node: trunkNodeRef,
-          ...(parentRef && { parent: parentRef }),
         });
       }),
     ...branchEdgeLayouts

--- a/src/client/src/atproto/branchState.ts
+++ b/src/client/src/atproto/branchState.ts
@@ -420,7 +420,7 @@ export async function createBranch(
       const rkey = makeRkey(branchId, node.id);
       const result = await deps.nodes.put(
         rkey,
-        nodeToRecord(node, sheetRef, now),
+        nodeToRecord(node, sheetRef, undefined, now),
       );
       nodeIdToBranchRef.set(node.id, { uri: result.uri, cid: result.cid });
     }),
@@ -579,7 +579,7 @@ export async function syncBranchSheetToAtproto(
       const rkey = makeRkey(branchId, node.id);
       const result = await deps.nodes.put(
         rkey,
-        nodeToRecord(node, sheetRef, now),
+        nodeToRecord(node, sheetRef, undefined, now),
       );
       nodeIdToRef.set(node.id, { uri: result.uri, cid: result.cid });
     }),

--- a/src/client/src/atproto/branchState.ts
+++ b/src/client/src/atproto/branchState.ts
@@ -426,6 +426,21 @@ export async function createBranch(
     }),
   );
 
+  // parentId → parentRef を解決して再書き込み (branch prefix 用に全 node の ref が揃ってから)
+  await Promise.all(
+    trunkData.nodes.map(async ({ node }) => {
+      if (!node.parentId) return;
+      const parentRef = nodeIdToBranchRef.get(node.parentId);
+      if (!parentRef) return;
+      const rkey = makeRkey(branchId, node.id);
+      const result = await deps.nodes.put(
+        rkey,
+        nodeToRecord(node, sheetRef, parentRef, now),
+      );
+      nodeIdToBranchRef.set(node.id, { uri: result.uri, cid: result.cid });
+    }),
+  );
+
   const edgeIdToBranchRef = new Map<string, StrongRef>();
   await Promise.all(
     trunkData.edges.map(async ({ edge }) => {
@@ -585,6 +600,21 @@ export async function syncBranchSheetToAtproto(
     }),
   );
 
+  // parentId → parentRef を解決して再書き込み
+  await Promise.all(
+    sheet.nodes.map(async (node) => {
+      if (!node.parentId) return;
+      const parentRef = nodeIdToRef.get(node.parentId);
+      if (!parentRef) return;
+      const rkey = makeRkey(branchId, node.id);
+      const result = await deps.nodes.put(
+        rkey,
+        nodeToRecord(node, sheetRef, parentRef, now),
+      );
+      nodeIdToRef.set(node.id, { uri: result.uri, cid: result.cid });
+    }),
+  );
+
   // edges
   const edgeIdToRef = new Map<string, StrongRef>();
   await Promise.all(
@@ -724,6 +754,25 @@ export async function mergeBranchToTrunk(
         sheet: sheetRef,
       });
       nodeIdToTrunkRef.set(nodeId, { uri: result.uri, cid: result.cid });
+    }),
+  );
+
+  // 1.5 parent の StrongRef を branch → trunk に付け替え
+  await Promise.all(
+    sheetBranchNodes.map(async (r) => {
+      const rec = r.value as NodeRecord;
+      if (!rec.parent) return;
+      const parentId = idFromRkey(rkeyFromUri(rec.parent.uri));
+      const trunkParentRef = nodeIdToTrunkRef.get(parentId);
+      if (!trunkParentRef) return;
+      const nodeId = idFromRkey(rkeyFromUri(r.uri));
+      const trunkRkey = makeRkey(TRUNK_PREFIX, nodeId);
+      const { $type: _, ...data } = rec;
+      await deps.nodes.put(trunkRkey, {
+        ...data,
+        sheet: sheetRef,
+        parent: trunkParentRef,
+      });
     }),
   );
 

--- a/src/client/src/atproto/mapper.test.ts
+++ b/src/client/src/atproto/mapper.test.ts
@@ -70,7 +70,7 @@ describe('nodeToRecord → recordToNode 往復', () => {
   };
 
   it('往復後に同じ内容になる', () => {
-    const record = nodeToRecord(node, SHEET_REF, NOW);
+    const record = nodeToRecord(node, SHEET_REF, undefined, NOW);
     const restored = recordToNode(node.id, {
       $type: 'app.conversensus.graph.node',
       ...record,
@@ -82,7 +82,7 @@ describe('nodeToRecord → recordToNode 往復', () => {
 
   it('properties が省略された場合 undefined になる', () => {
     const noProps: GraphNode = { id: node.id, content: 'no props' };
-    const record = nodeToRecord(noProps, SHEET_REF, NOW);
+    const record = nodeToRecord(noProps, SHEET_REF, undefined, NOW);
     expect('properties' in record).toBe(false);
     const restored = recordToNode(noProps.id, {
       $type: 'app.conversensus.graph.node',
@@ -153,20 +153,22 @@ describe('nodeLayoutToRecord → recordToNodeLayout 往復', () => {
       nodeId: NODE_ID as NodeLayout['nodeId'],
       width: '120',
     };
-    const record = nodeLayoutToRecord(layout, NODE_REF, undefined, NOW);
+    const record = nodeLayoutToRecord(layout, NODE_REF, NOW);
     expect(record.width).toBe(120);
   });
 
-  it('parentId ↔ parent.uri が正しく変換される', () => {
-    const layout: NodeLayout = {
-      nodeId: NODE_ID as NodeLayout['nodeId'],
+  it('parentId / nodeType は nodeToRecord → recordToNode 往復で保持される', () => {
+    const groupedNode: GraphNode = {
+      id: NODE_ID as GraphNode['id'],
+      content: '子ノード',
       nodeType: 'group',
-      parentId: PARENT_ID as NodeLayout['parentId'],
+      parentId: PARENT_ID as GraphNode['parentId'],
     };
-    const record = nodeLayoutToRecord(layout, NODE_REF, PARENT_REF, NOW);
+    const record = nodeToRecord(groupedNode, SHEET_REF, PARENT_REF, NOW);
     expect(record.parent?.uri).toContain(PARENT_ID);
-    const restored = recordToNodeLayout(NODE_ID, {
-      $type: 'app.conversensus.graph.nodeLayout',
+    expect(record.nodeType).toBe('group');
+    const restored = recordToNode(NODE_ID, {
+      $type: 'app.conversensus.graph.node',
       ...record,
     });
     expect(restored.parentId).toBe(PARENT_ID);

--- a/src/client/src/atproto/mapper.ts
+++ b/src/client/src/atproto/mapper.ts
@@ -62,12 +62,15 @@ export function sheetToRecord(
 export function nodeToRecord(
   node: GraphNode,
   sheetRef: StrongRef,
+  parentRef?: StrongRef,
   createdAt = new Date().toISOString(),
 ): Omit<NodeRecord, '$type'> {
   return {
     sheet: sheetRef,
     content: node.content,
     ...(node.properties !== undefined && { properties: node.properties }),
+    ...(node.nodeType !== undefined && { nodeType: node.nodeType }),
+    ...(parentRef !== undefined && { parent: parentRef }),
     createdAt,
   };
 }
@@ -99,7 +102,6 @@ function toInt(value: number | string | undefined): number | undefined {
 export function nodeLayoutToRecord(
   layout: NodeLayout,
   nodeRef: StrongRef,
-  parentRef?: StrongRef,
   createdAt = new Date().toISOString(),
 ): Omit<NodeLayoutRecord, '$type'> {
   return {
@@ -108,8 +110,6 @@ export function nodeLayoutToRecord(
     ...(layout.y !== undefined && { y: Math.round(layout.y) }),
     ...(layout.width !== undefined && { width: toInt(layout.width) }),
     ...(layout.height !== undefined && { height: toInt(layout.height) }),
-    ...(layout.nodeType !== undefined && { nodeType: layout.nodeType }),
-    ...(parentRef !== undefined && { parent: parentRef }),
     createdAt,
   };
 }
@@ -152,6 +152,10 @@ export function recordToNode(rkey: string, record: NodeRecord): GraphNode {
     ...(record.properties !== undefined && {
       properties: record.properties as Record<string, unknown>,
     }),
+    ...(record.nodeType !== undefined && { nodeType: record.nodeType }),
+    ...(record.parent !== undefined && {
+      parentId: NodeIdSchema.parse(idFromRkey(rkeyFromUri(record.parent.uri))),
+    }),
   };
 }
 
@@ -177,10 +181,6 @@ export function recordToNodeLayout(
     ...(record.y !== undefined && { y: record.y }),
     ...(record.width !== undefined && { width: record.width }),
     ...(record.height !== undefined && { height: record.height }),
-    ...(record.nodeType !== undefined && { nodeType: record.nodeType }),
-    ...(record.parent !== undefined && {
-      parentId: NodeIdSchema.parse(idFromRkey(rkeyFromUri(record.parent.uri))),
-    }),
   };
 }
 

--- a/src/client/src/atproto/sync.ts
+++ b/src/client/src/atproto/sync.ts
@@ -119,14 +119,11 @@ export async function syncSheetToAtproto(
       sheet.layouts.map(async (layout) => {
         const nodeRef = nodeRefs.get(layout.nodeId);
         if (!nodeRef) return;
-        const parentRef = layout.parentId
-          ? nodeRefs.get(layout.parentId)
-          : undefined;
         const rkey = makeRkey(TRUNK_PREFIX, layout.nodeId);
         const layoutCreatedAt = getCreatedAt(NSID.nodeLayout, rkey) ?? now;
         const r = await nodeLayouts.put(
           rkey,
-          nodeLayoutToRecord(layout, nodeRef, parentRef, layoutCreatedAt),
+          nodeLayoutToRecord(layout, nodeRef, layoutCreatedAt),
         );
         cacheResult(r.uri, r.cid, layoutCreatedAt);
       }),

--- a/src/client/src/atproto/sync.ts
+++ b/src/client/src/atproto/sync.ts
@@ -90,6 +90,23 @@ export async function syncSheetToAtproto(
     }),
   );
 
+  // 2.5 parentId → parentRef を解決して再書き込み (全 node の ref が揃ってから)
+  await Promise.all(
+    sheet.nodes.map(async (node) => {
+      if (!node.parentId) return;
+      const parentRef = nodeRefs.get(node.parentId);
+      if (!parentRef) return;
+      const rkey = makeRkey(TRUNK_PREFIX, node.id);
+      const nodeCreatedAt = getCreatedAt(NSID.node, rkey) ?? now;
+      const result = await nodes.put(
+        rkey,
+        nodeToRecord(node, sheetRef, parentRef, nodeCreatedAt),
+      );
+      cacheResult(result.uri, result.cid, nodeCreatedAt);
+      nodeRefs.set(node.id, { uri: result.uri, cid: result.cid });
+    }),
+  );
+
   // 3. 全 edge を put (並列、nodeRefs が確定してから)
   const edgeRefs = new Map<string, StrongRef>();
   await Promise.all(

--- a/src/client/src/atproto/sync.ts
+++ b/src/client/src/atproto/sync.ts
@@ -83,7 +83,7 @@ export async function syncSheetToAtproto(
       const nodeCreatedAt = getCreatedAt(NSID.node, rkey) ?? now;
       const result = await nodes.put(
         rkey,
-        nodeToRecord(node, sheetRef, nodeCreatedAt),
+        nodeToRecord(node, sheetRef, undefined, nodeCreatedAt),
       );
       cacheResult(result.uri, result.cid, nodeCreatedAt);
       nodeRefs.set(node.id, { uri: result.uri, cid: result.cid });

--- a/src/client/src/atproto/types.ts
+++ b/src/client/src/atproto/types.ts
@@ -34,6 +34,8 @@ export type NodeRecord = {
   sheet: StrongRef;
   content: string;
   properties?: unknown;
+  nodeType?: 'group';
+  parent?: StrongRef;
   createdAt: string;
 };
 
@@ -54,8 +56,6 @@ export type NodeLayoutRecord = {
   y?: number;
   width?: number;
   height?: number;
-  nodeType?: 'group';
-  parent?: StrongRef;
   createdAt: string;
 };
 

--- a/src/client/src/events/applyEvent.test.ts
+++ b/src/client/src/events/applyEvent.test.ts
@@ -50,7 +50,6 @@ const graphEdge: GraphEdge = {
   source: 'n1' as NodeId,
   target: 'n2' as NodeId,
   label: 'ラベル',
-  pathType: 'straight',
 };
 
 // --- structure イベント ---
@@ -178,6 +177,7 @@ describe('NODES_GROUPED', () => {
     const parentData: GraphNode = {
       id: 'parent' as NodeId,
       content: 'グループ',
+      nodeType: 'group',
     };
     const parentLayout: NodeLayout = {
       nodeId: 'parent' as NodeId,
@@ -185,7 +185,6 @@ describe('NODES_GROUPED', () => {
       y: 0,
       width: 200,
       height: 200,
-      nodeType: 'group',
     };
     const event: GraphEvent = {
       ...base,
@@ -229,12 +228,12 @@ describe('NODES_UNGROUPED', () => {
     const parentData: GraphNode = {
       id: 'parent' as NodeId,
       content: 'グループ',
+      nodeType: 'group',
     };
     const parentLayout: NodeLayout = {
       nodeId: 'parent' as NodeId,
       x: 0,
       y: 0,
-      nodeType: 'group',
     };
     const event: GraphEvent = {
       ...base,

--- a/src/client/src/events/invertEvent.test.ts
+++ b/src/client/src/events/invertEvent.test.ts
@@ -13,7 +13,6 @@ const base = { id: 'evt', timestamp: 0, userId: 'local' } as const;
 const graphNode: GraphNode = {
   id: 'n1' as NodeId,
   content: 'ノード1',
-  style: { x: 10, y: 20 },
 };
 const graphEdge: GraphEdge = {
   id: 'e1' as EdgeId,
@@ -132,7 +131,6 @@ describe('NODES_GROUPED ↔ NODES_UNGROUPED', () => {
   const parentData: GraphNode = {
     id: 'parent' as NodeId,
     content: 'グループ',
-    style: { x: 0, y: 0, nodeType: 'group' },
   };
 
   it('NODES_GROUPED の逆は NODES_UNGROUPED (同じ children を保持)', () => {

--- a/src/client/src/graphTransform.test.ts
+++ b/src/client/src/graphTransform.test.ts
@@ -277,32 +277,27 @@ describe('toFlowNodes → fromFlowNodes の対称性', () => {
 });
 
 describe('toFlowNodes: グループノード (parentId / nodeType)', () => {
-  it('nodeType=group の NodeLayout は groupNode 型に変換される', () => {
-    const nodes: GraphNode[] = [{ id: 'g1' as NodeId, content: 'グループ' }];
+  it('nodeType=group の GraphNode は groupNode 型に変換される', () => {
+    const nodes: GraphNode[] = [
+      { id: 'g1' as NodeId, content: 'グループ', nodeType: 'group' },
+    ];
     const layouts: NodeLayout[] = [
-      {
-        nodeId: 'g1' as NodeId,
-        x: 0,
-        y: 0,
-        width: 200,
-        height: 150,
-        nodeType: 'group',
-      },
+      { nodeId: 'g1' as NodeId, x: 0, y: 0, width: 200, height: 150 },
     ];
     expect(toFlowNodes(nodes, layouts)[0].type).toBe('groupNode');
   });
 
-  it('parentId を持つ NodeLayout は parentId が引き継がれる', () => {
-    const nodes: GraphNode[] = [{ id: 'n1' as NodeId, content: 'child' }];
-    const layouts: NodeLayout[] = [
-      { nodeId: 'n1' as NodeId, x: 20, y: 50, parentId: 'g1' as NodeId },
+  it('parentId を持つ GraphNode は parentId が引き継がれる', () => {
+    const nodes: GraphNode[] = [
+      { id: 'n1' as NodeId, content: 'child', parentId: 'g1' as NodeId },
     ];
+    const layouts: NodeLayout[] = [{ nodeId: 'n1' as NodeId, x: 20, y: 50 }];
     expect(toFlowNodes(nodes, layouts)[0].parentId).toBe('g1');
   });
 });
 
 describe('fromFlowNodes: parentId / groupNode', () => {
-  it('parentId を持つ Node は layout.parentId として保存される', () => {
+  it('parentId を持つ Node は GraphNode.parentId として保存される', () => {
     const flowNodes: Node[] = [
       {
         id: 'n1',
@@ -313,11 +308,11 @@ describe('fromFlowNodes: parentId / groupNode', () => {
       },
     ];
     const result = fromFlowNodes(flowNodes);
-    expect(result.nodes[0]).not.toHaveProperty('parentId');
-    expect(result.layouts[0].parentId).toBe('g1');
+    expect(result.nodes[0].parentId).toBe('g1');
+    expect(result.layouts[0]).not.toHaveProperty('parentId');
   });
 
-  it('groupNode 型は layout.nodeType=group として保存される', () => {
+  it('groupNode 型は GraphNode.nodeType=group として保存される', () => {
     const flowNodes: Node[] = [
       {
         id: 'g1',
@@ -326,7 +321,8 @@ describe('fromFlowNodes: parentId / groupNode', () => {
         type: 'groupNode',
       },
     ];
-    expect(fromFlowNodes(flowNodes).layouts[0].nodeType).toBe('group');
+    expect(fromFlowNodes(flowNodes).nodes[0].nodeType).toBe('group');
+    expect(fromFlowNodes(flowNodes).layouts[0]).not.toHaveProperty('nodeType');
   });
 });
 

--- a/src/client/src/graphTransform.ts
+++ b/src/client/src/graphTransform.ts
@@ -19,7 +19,7 @@ export function toFlowNodes(
   conflictedNodeIds?: Set<string>,
 ): Node[] {
   const layoutMap = new Map(layouts.map((l) => [l.nodeId as string, l]));
-  return nodes.map((n) => {
+  const result = nodes.map((n) => {
     const layout = layoutMap.get(n.id) ?? {
       nodeId: n.id as NodeId,
       x: 0,
@@ -43,6 +43,35 @@ export function toFlowNodes(
           : DEFAULT_NODE_STYLE,
     };
   });
+
+  // ReactFlow は親ノードが子ノードより前方に並ぶことを要求するためトポロジカルソート
+  const sorted: Node[] = [];
+  const remaining = new Map(result.map((n) => [n.id, n]));
+  const placed = new Set<string>();
+
+  for (const n of result) {
+    if (!n.parentId) {
+      sorted.push(n);
+      placed.add(n.id);
+      remaining.delete(n.id);
+    }
+  }
+
+  let progress = true;
+  while (remaining.size > 0 && progress) {
+    progress = false;
+    for (const [id, n] of remaining) {
+      if (n.parentId && placed.has(n.parentId)) {
+        sorted.push(n);
+        placed.add(id);
+        remaining.delete(id);
+        progress = true;
+      }
+    }
+  }
+  sorted.push(...remaining.values()); // 循環参照などで残ったものを末尾に追加
+
+  return sorted;
 }
 
 export function toFlowEdges(

--- a/src/client/src/graphTransform.ts
+++ b/src/client/src/graphTransform.ts
@@ -35,8 +35,8 @@ export function toFlowNodes(
         label: n.content,
         conflicted: conflictedNodeIds?.has(n.id) ?? false,
       },
-      type: layout.nodeType === 'group' ? 'groupNode' : 'editableNode',
-      parentId: layout.parentId,
+      type: n.nodeType === 'group' ? 'groupNode' : 'editableNode',
+      parentId: n.parentId,
       style:
         layout.width !== undefined || layout.height !== undefined
           ? { width: layout.width, height: layout.height }
@@ -82,6 +82,8 @@ export function fromFlowNodes(nodes: Node[]): {
   const graphNodes: GraphNode[] = nodes.map((n) => ({
     id: n.id as NodeId,
     content: String(n.data.label ?? ''),
+    ...(n.type === 'groupNode' ? { nodeType: 'group' as const } : {}),
+    ...(n.parentId ? { parentId: n.parentId as NodeId } : {}),
   }));
 
   const layouts: NodeLayout[] = nodes.map((n) => ({
@@ -90,8 +92,6 @@ export function fromFlowNodes(nodes: Node[]): {
     y: n.position.y,
     width: n.style?.width as number | string | undefined,
     height: n.style?.height as number | string | undefined,
-    ...(n.type === 'groupNode' ? { nodeType: 'group' as const } : {}),
-    ...(n.parentId ? { parentId: n.parentId as NodeId } : {}),
   }));
 
   return { nodes: graphNodes, layouts };

--- a/src/client/src/hooks/useGroupNodes.ts
+++ b/src/client/src/hooks/useGroupNodes.ts
@@ -54,6 +54,8 @@ export function useGroupNodes(
     const parentData: GraphNode = {
       id: parentId,
       content: 'グループ',
+      nodeType: 'group',
+      ...(sharedParentId ? { parentId: sharedParentId as NodeId } : {}),
     };
 
     const parentLayout: NodeLayout = {
@@ -62,8 +64,6 @@ export function useGroupNodes(
       y: parentY,
       width: parentWidth,
       height: parentHeight,
-      nodeType: 'group',
-      ...(sharedParentId ? { parentId: sharedParentId as NodeId } : {}),
     };
 
     const children = selected.map((n) => ({

--- a/src/server/src/index.ts
+++ b/src/server/src/index.ts
@@ -3,12 +3,14 @@ import {
   ConversensusFileSchema,
   ConversensusFileV1Schema,
   ConversensusFileV2Schema,
+  ConversensusFileV3Schema,
   CreateFileRequestSchema,
   type EdgeId,
   type FileId,
   type GraphFile,
   migrateV1toV2,
   migrateV2toV3,
+  migrateV3toV4,
   type NodeId,
   type SheetId,
   UpdateFileRequestSchema,
@@ -95,25 +97,32 @@ app.put('/files/:id', async (c) => {
 app.post('/files/import', async (c) => {
   const raw = await c.req.json().catch(() => null);
 
-  // v3 を試み, 失敗したら v2→v3, さらに失敗したら v1→v2→v3 マイグレーション
+  // v4 を試み, 失敗したら v3→v4, v2→v3→v4, v1→v2→v3→v4 とマイグレーション
   let parsedFile: ReturnType<typeof ConversensusFileSchema.safeParse>;
-  const parsedV3 = ConversensusFileSchema.safeParse(raw);
-  if (parsedV3.success) {
-    parsedFile = parsedV3;
+  const parsedV4 = ConversensusFileSchema.safeParse(raw);
+  if (parsedV4.success) {
+    parsedFile = parsedV4;
   } else {
-    const parsedV2 = ConversensusFileV2Schema.safeParse(raw);
-    if (parsedV2.success) {
+    const parsedV3 = ConversensusFileV3Schema.safeParse(raw);
+    if (parsedV3.success) {
       parsedFile = ConversensusFileSchema.safeParse(
-        migrateV2toV3(parsedV2.data),
+        migrateV3toV4(parsedV3.data),
       );
     } else {
-      const parsedV1 = ConversensusFileV1Schema.safeParse(raw);
-      if (parsedV1.success) {
+      const parsedV2 = ConversensusFileV2Schema.safeParse(raw);
+      if (parsedV2.success) {
         parsedFile = ConversensusFileSchema.safeParse(
-          migrateV2toV3(migrateV1toV2(parsedV1.data)),
+          migrateV3toV4(migrateV2toV3(parsedV2.data)),
         );
       } else {
-        return c.json({ error: parsedV3.error.flatten() }, 400);
+        const parsedV1 = ConversensusFileV1Schema.safeParse(raw);
+        if (parsedV1.success) {
+          parsedFile = ConversensusFileSchema.safeParse(
+            migrateV3toV4(migrateV2toV3(migrateV1toV2(parsedV1.data))),
+          );
+        } else {
+          return c.json({ error: parsedV4.error.flatten() }, 400);
+        }
       }
     }
   }
@@ -141,6 +150,9 @@ app.post('/files/import', async (c) => {
           ...n,
           // biome-ignore lint/style/noNonNullAssertion: nodeIdMap は同じ nodes 配列から構築されるため必ず存在する
           id: nodeIdMap.get(n.id)!,
+          ...(n.parentId
+            ? { parentId: (nodeIdMap.get(n.parentId) ?? n.parentId) as NodeId }
+            : {}),
         })),
         edges: sheet.edges.map((e) => ({
           ...e,
@@ -152,9 +164,6 @@ app.post('/files/import', async (c) => {
         layouts: sheet.layouts?.map((l) => ({
           ...l,
           nodeId: (nodeIdMap.get(l.nodeId) ?? l.nodeId) as NodeId,
-          ...(l.parentId
-            ? { parentId: (nodeIdMap.get(l.parentId) ?? l.parentId) as NodeId }
-            : {}),
         })),
         edgeLayouts: sheet.edgeLayouts?.map((l) => ({
           ...l,

--- a/src/shared/src/migrations.ts
+++ b/src/shared/src/migrations.ts
@@ -2,8 +2,10 @@ import { z } from 'zod';
 import {
   type ConversensusFile,
   EdgeIdSchema,
+  EdgeLayoutSchema,
   EdgePathTypeSchema,
   FileIdSchema,
+  GraphEdgeSchema,
   GraphFileSchema,
   GraphNodeSchema,
   type NodeId,
@@ -89,6 +91,50 @@ export const ConversensusFileV2Schema = GraphFileV2Schema.extend({
 });
 export type ConversensusFileV2 = z.infer<typeof ConversensusFileV2Schema>;
 
+// --- v3 互換スキーマ (マイグレーション専用) ---
+
+// v3 ノード: nodeType と parentId なし (v4 で GraphNode に追加)
+const GraphNodeV3Schema = z.object({
+  id: NodeIdSchema,
+  content: z.string(),
+  properties: z.record(z.string(), z.unknown()).optional(),
+});
+
+// v3 レイアウト: nodeType と parentId を含む (v4 で NodeLayout から削除)
+const NodeLayoutV3Schema = z
+  .object({
+    nodeId: NodeIdSchema,
+    x: z.number().optional(),
+    y: z.number().optional(),
+    width: z.union([z.number(), z.string()]).optional(),
+    height: z.union([z.number(), z.string()]).optional(),
+    nodeType: z.literal('group').optional(),
+    parentId: NodeIdSchema.optional(),
+  })
+  .catchall(z.unknown());
+
+const SheetV3Schema = z.object({
+  id: SheetIdSchema,
+  name: z.string(),
+  description: z.string().optional(),
+  nodes: z.array(GraphNodeV3Schema),
+  edges: z.array(GraphEdgeSchema),
+  layouts: z.array(NodeLayoutV3Schema).optional(),
+  edgeLayouts: z.array(EdgeLayoutSchema).optional(),
+});
+
+const GraphFileV3Schema = z.object({
+  id: FileIdSchema,
+  name: z.string(),
+  description: z.string().optional(),
+  sheets: z.array(SheetV3Schema),
+});
+
+export const ConversensusFileV3Schema = GraphFileV3Schema.extend({
+  version: z.literal('3'),
+});
+export type ConversensusFileV3 = z.infer<typeof ConversensusFileV3Schema>;
+
 // --- マイグレーション関数 ---
 
 // v1 → v2: style/エッジレイアウトフィールドを NodeLayout/EdgeLayout に分離
@@ -151,6 +197,41 @@ export function migrateV1toV2(file: ConversensusFileV1): ConversensusFileV2 {
         })),
         layouts: layouts.length > 0 ? layouts : undefined,
         edgeLayouts: edgeLayouts.length > 0 ? edgeLayouts : undefined,
+      };
+    }),
+  };
+}
+
+// v3 → v4: nodeType/parentId をレイアウトからセマンティックノードに移動
+export function migrateV3toV4(file: ConversensusFileV3): ConversensusFile {
+  return {
+    ...file,
+    version: '4',
+    sheets: file.sheets.map((sheet) => {
+      // レイアウトから nodeType と parentId を収集
+      const nodeMetaMap = new Map<
+        string,
+        { nodeType?: 'group'; parentId?: NodeId }
+      >(
+        (sheet.layouts ?? [])
+          .filter((l) => l.nodeType !== undefined || l.parentId !== undefined)
+          .map((l) => [
+            l.nodeId as string,
+            {
+              ...(l.nodeType !== undefined ? { nodeType: l.nodeType } : {}),
+              ...(l.parentId !== undefined ? { parentId: l.parentId } : {}),
+            },
+          ]),
+      );
+      return {
+        ...sheet,
+        nodes: sheet.nodes.map((n) => ({
+          ...n,
+          ...(nodeMetaMap.get(n.id as string) ?? {}),
+        })),
+        layouts: (sheet.layouts ?? []).map(
+          ({ nodeType: _nt, parentId: _pid, ...rest }) => rest,
+        ),
       };
     }),
   };

--- a/src/shared/src/schemas.ts
+++ b/src/shared/src/schemas.ts
@@ -32,8 +32,6 @@ export const NodeLayoutSchema = z
     y: z.number().optional(),
     width: z.union([z.number(), z.string()]).optional(),
     height: z.union([z.number(), z.string()]).optional(),
-    nodeType: z.literal('group').optional(),
-    parentId: NodeIdSchema.optional(),
   })
   .catchall(z.unknown());
 export type NodeLayout = z.infer<typeof NodeLayoutSchema>;
@@ -43,6 +41,8 @@ export const GraphNodeSchema = z.object({
   id: NodeIdSchema,
   content: z.string(),
   properties: z.record(z.string(), z.unknown()).optional(),
+  nodeType: z.literal('group').optional(),
+  parentId: NodeIdSchema.optional(),
 });
 
 export const EdgePathTypeSchema = z.enum([
@@ -120,12 +120,15 @@ export const CommitOperationSchema = z.discriminatedUnion('op', [
     nodeId: z.string().uuid(),
     content: z.string(),
     properties: z.record(z.string(), z.unknown()).optional(),
+    nodeType: z.literal('group').optional(),
+    parentId: z.string().uuid().optional(),
   }),
   z.object({
     op: z.literal('node.update'),
     nodeId: z.string().uuid(),
     content: z.string().optional(),
     properties: z.record(z.string(), z.unknown()).optional(),
+    parentId: z.string().uuid().optional(),
   }),
   z.object({ op: z.literal('node.remove'), nodeId: z.string().uuid() }),
   z.object({
@@ -147,7 +150,7 @@ export const CommitOperationSchema = z.discriminatedUnion('op', [
 export type CommitOperation = z.infer<typeof CommitOperationSchema>;
 
 // --- Current file format ---
-export const CONVERSENSUS_FILE_VERSION = '3' as const;
+export const CONVERSENSUS_FILE_VERSION = '4' as const;
 
 // .conversensus ファイル形式: GraphFile に version ヘッダを付与
 export const ConversensusFileSchema = GraphFileSchema.extend({


### PR DESCRIPTION
## Summary
`nodeType: 'group'` と `parentId` を `NodeLayout`（プレゼンテーション層）から `GraphNode`（セマンティック層）へ移動。あわせて branch/commit でグループ構造を扱えるよう `CommitOperation` を拡張。

### 変更内容
- **データモデル**: GraphNodeSchema に nodeType/parentId 追加、NodeLayoutSchema から削除
- **CommitOperation**: node.add に nodeType/parentId、node.update に parentId を追加
- **computeOperations**: nodeType/parentId の比較を追加
- **ファイルバージョン**: v3→v4、migrateV3toV4 追加
- **ATProto**: NodeRecord に nodeType/parent(StrongRef) 追加、NodeLayoutRecord から削除
- **変換層**: toFlowNodes/fromFlowNodes で GraphNode から読み書き
- **イベント/UI**: useGroupNodes/GroupNode で parentData に nodeType/parentId 設定
- **Import**: サーバー/Sidebar に v3→v4 マイグレーションチェーン追加

### 15 files changed
### Test plan
- [x] lint / typecheck パス
- [x] 286 tests pass (0 fail)

Closes ANA-47

🤖 Generated with [Claude Code](https://claude.com/claude-code)