### PR TITLE
refactor: 原始型エイリアス追加 + マジックリテラル定数化 (ANA-86, ANA-87)

### DIFF
--- a/src/client/src/AlertDialog.tsx
+++ b/src/client/src/AlertDialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { DIALOG_WIDTH, DIALOG_Z_INDEX } from './ConfirmDialog';
 
 type Props = {
   message: string;
@@ -23,7 +24,7 @@ export function AlertDialog({ message, onClose, closeLabel = 'OK' }: Props) {
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        zIndex: 1000,
+        zIndex: DIALOG_Z_INDEX,
       }}
       onClick={onClose}
       onKeyDown={(e) => {
@@ -38,7 +39,7 @@ export function AlertDialog({ message, onClose, closeLabel = 'OK' }: Props) {
           background: '#fff',
           borderRadius: 8,
           padding: 24,
-          width: 380,
+          width: DIALOG_WIDTH,
           maxWidth: '90vw',
           boxShadow: '0 4px 24px rgba(0,0,0,0.2)',
         }}

--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -1,7 +1,12 @@
 import type { GraphFile, Sheet, SheetId } from '@conversensus/shared';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { AlertDialog } from './AlertDialog';
-import { sheets, syncBranchSheetToAtproto } from './atproto';
+import {
+  BRANCH_STATUS,
+  sheets,
+  syncBranchSheetToAtproto,
+  TRUNK_PREFIX,
+} from './atproto';
 import { CommitDialog } from './CommitDialog';
 import { ConfirmDialog } from './ConfirmDialog';
 import { GraphEditor } from './GraphEditor';
@@ -9,6 +14,7 @@ import { useBranchOperations } from './hooks/useBranchOperations';
 import type { UndoState } from './hooks/useEventStore';
 import { useFileSheetOperations } from './hooks/useFileSheetOperations';
 import { InputDialog } from './InputDialog';
+import { FLOATING_UI_Z_INDEX } from './SettingsPopup';
 import { Sidebar } from './Sidebar';
 import { generateId } from './uuid';
 
@@ -58,9 +64,9 @@ export default function App() {
       saveTimer.current = setTimeout(async () => {
         if (
           branch &&
-          branch.name !== 'trunk' &&
+          branch.name !== TRUNK_PREFIX &&
           sheetId &&
-          branch.status === 'open'
+          branch.status === BRANCH_STATUS.OPEN
         ) {
           const sheet = updated.sheets.find((s) => s.id === sheetId);
           if (!sheet) return;
@@ -156,8 +162,8 @@ export default function App() {
       <main style={{ flex: 1 }}>
         {fileOps.activeFile && fileOps.activeSheetId ? (
           <GraphEditor
-            key={`${fileOps.activeSheetId}/${branchOps.activeBranch?.id ?? 'trunk'}`}
-            graphKey={`${fileOps.activeSheetId}/${branchOps.activeBranch?.id ?? 'trunk'}`}
+            key={`${fileOps.activeSheetId}/${branchOps.activeBranch?.id ?? TRUNK_PREFIX}`}
+            graphKey={`${fileOps.activeSheetId}/${branchOps.activeBranch?.id ?? TRUNK_PREFIX}`}
             undoStateMap={undoStateMapRef}
             file={fileOps.activeFile}
             activeSheetId={fileOps.activeSheetId}
@@ -179,13 +185,13 @@ export default function App() {
           </div>
         )}
       </main>
-      {!branchOps.isTrunk && branch && branch.status === 'open' && (
+      {!branchOps.isTrunk && branch && branch.status === BRANCH_STATUS.OPEN && (
         <div
           style={{
             position: 'fixed',
             bottom: 24,
             right: 24,
-            zIndex: 100,
+            zIndex: FLOATING_UI_Z_INDEX,
             display: 'flex',
             gap: 8,
             alignItems: 'center',
@@ -229,7 +235,7 @@ export default function App() {
             disabled={
               branchOps.pendingOps.length > 0 ||
               branchOps.newCommitsSinceMerge === 0 ||
-              branch.status === 'closed'
+              branch.status === BRANCH_STATUS.CLOSED
             }
             style={{
               padding: '6px 16px',
@@ -237,7 +243,7 @@ export default function App() {
               background:
                 branchOps.pendingOps.length === 0 &&
                 branchOps.newCommitsSinceMerge > 0 &&
-                branch.status !== 'closed'
+                branch.status !== BRANCH_STATUS.CLOSED
                   ? '#f97316'
                   : '#ccc',
               color: '#fff',
@@ -246,7 +252,7 @@ export default function App() {
               cursor:
                 branchOps.pendingOps.length === 0 &&
                 branchOps.newCommitsSinceMerge > 0 &&
-                branch.status !== 'closed'
+                branch.status !== BRANCH_STATUS.CLOSED
                   ? 'pointer'
                   : 'not-allowed',
             }}

--- a/src/client/src/CommitDialog.tsx
+++ b/src/client/src/CommitDialog.tsx
@@ -1,5 +1,6 @@
 import type { CommitOperation } from '@conversensus/shared';
 import { useEffect, useRef, useState } from 'react';
+import { DIALOG_Z_INDEX } from './ConfirmDialog';
 
 type Props = {
   operations: CommitOperation[];
@@ -39,7 +40,7 @@ export function CommitDialog({ operations, onCommit, onCancel }: Props) {
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        zIndex: 1000,
+        zIndex: DIALOG_Z_INDEX,
       }}
       onClick={handleBackdropClick}
     >

--- a/src/client/src/ConfirmDialog.tsx
+++ b/src/client/src/ConfirmDialog.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useRef } from 'react';
 
+export const DIALOG_Z_INDEX = 1000;
+export const DIALOG_WIDTH = 380;
+
 type Props = {
   message: string;
   onConfirm: () => void;
@@ -31,7 +34,7 @@ export function ConfirmDialog({
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        zIndex: 1000,
+        zIndex: DIALOG_Z_INDEX,
       }}
       onClick={onCancel}
       onKeyDown={(e) => {
@@ -46,7 +49,7 @@ export function ConfirmDialog({
           background: '#fff',
           borderRadius: 8,
           padding: 24,
-          width: 380,
+          width: DIALOG_WIDTH,
           maxWidth: '90vw',
           boxShadow: '0 4px 24px rgba(0,0,0,0.2)',
         }}

--- a/src/client/src/EdgeContextMenu.tsx
+++ b/src/client/src/EdgeContextMenu.tsx
@@ -1,4 +1,6 @@
 import type { EdgePathType } from '@conversensus/shared';
+import { DIALOG_Z_INDEX } from './ConfirmDialog';
+import { DEFAULT_EDGE_PATH_TYPE } from './graphTransform';
 import type { EdgeContextMenuState } from './hooks/useEdgeContextMenu';
 
 type Props = {
@@ -18,7 +20,7 @@ export function EdgeContextMenu({ contextMenu, onSelect }: Props) {
         border: '1px solid #ddd',
         borderRadius: 6,
         boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
-        zIndex: 1000,
+        zIndex: DIALOG_Z_INDEX,
         minWidth: 160,
         padding: '4px 0',
       }}
@@ -39,7 +41,7 @@ export function EdgeContextMenu({ contextMenu, onSelect }: Props) {
       </div>
       {(
         [
-          ['bezier', 'Bezier（曲線）'],
+          [DEFAULT_EDGE_PATH_TYPE, 'Bezier（曲線）'],
           ['straight', 'Straight（直線）'],
           ['step', 'Step（直角）'],
           ['smoothstep', 'Smooth Step（角丸）'],

--- a/src/client/src/EditableLabelEdge.tsx
+++ b/src/client/src/EditableLabelEdge.tsx
@@ -11,6 +11,7 @@ import {
 import { useCallback, useRef } from 'react';
 import { useEventDispatch } from './EventDispatchContext';
 import { makeEventBase } from './events/GraphEvent';
+import { DEFAULT_EDGE_PATH_TYPE } from './graphTransform';
 import { useInlineEdit } from './hooks/useInlineEdit';
 
 function getEdgePath(
@@ -54,7 +55,8 @@ export function EditableLabelEdge({
   const { setEdges } = useReactFlow();
   const { dispatch, setDragging } = useEventDispatch();
 
-  const pathType = (data?.pathType as EdgePathType | undefined) ?? 'bezier';
+  const pathType =
+    (data?.pathType as EdgePathType | undefined) ?? DEFAULT_EDGE_PATH_TYPE;
   const [edgePath, labelX, labelY] = getEdgePath(pathType, {
     sourceX,
     sourceY,

--- a/src/client/src/GraphEditor.tsx
+++ b/src/client/src/GraphEditor.tsx
@@ -1,7 +1,6 @@
 import type {
   EdgeId,
   EdgeLayout,
-  EdgePathType,
   GraphEdge,
   GraphNode,
   NodeId,
@@ -40,9 +39,15 @@ import { EventDispatchContext } from './EventDispatchContext';
 import { makeEventBase } from './events/GraphEvent';
 import { GroupNode } from './GroupNode';
 import {
+  DEFAULT_EDGE_PATH_TYPE,
   DEFAULT_NODE_STYLE,
   fromFlowEdges,
   fromFlowNodes,
+  PNG_EXPORT_HEIGHT,
+  PNG_EXPORT_MAX_ZOOM,
+  PNG_EXPORT_MIN_ZOOM,
+  PNG_EXPORT_PADDING,
+  PNG_EXPORT_WIDTH,
   toFlowEdges,
   toFlowNodes,
 } from './graphTransform';
@@ -51,6 +56,8 @@ import { useEdgeContextMenu } from './hooks/useEdgeContextMenu';
 import { type UndoState, useEventStore } from './hooks/useEventStore';
 import { useGroupNodes } from './hooks/useGroupNodes';
 import { usePaneDoubleClick } from './hooks/usePaneDoubleClick';
+
+const RF_INIT_DELAY_MS = 150;
 
 type Props = {
   file: GraphFile;
@@ -123,7 +130,7 @@ function GraphEditorInner({
     // ReactFlow の初期 dimensions 計測が完了するまで onChange を抑制 (150ms)
     const t = setTimeout(() => {
       readyForSave.current = true;
-    }, 150);
+    }, RF_INIT_DELAY_MS);
     return () => clearTimeout(t);
   }, [file.id, activeSheetId, setNodes, setEdges]);
 
@@ -271,7 +278,7 @@ function GraphEditorInner({
         edgeId,
         sourceHandle: connection.sourceHandle ?? undefined,
         targetHandle: connection.targetHandle ?? undefined,
-        pathType: 'bezier' satisfies EdgePathType,
+        pathType: DEFAULT_EDGE_PATH_TYPE,
       };
       dispatch({
         ...makeEventBase('structure'),
@@ -379,9 +386,16 @@ function GraphEditorInner({
   const handleExportPng = useCallback(() => {
     const nodes = getNodes();
     const bounds = getNodesBounds(nodes);
-    const width = 1920;
-    const height = 1080;
-    const viewport = getViewportForBounds(bounds, width, height, 0.5, 2, 0.1);
+    const width = PNG_EXPORT_WIDTH;
+    const height = PNG_EXPORT_HEIGHT;
+    const viewport = getViewportForBounds(
+      bounds,
+      width,
+      height,
+      PNG_EXPORT_MIN_ZOOM,
+      PNG_EXPORT_MAX_ZOOM,
+      PNG_EXPORT_PADDING,
+    );
     const viewportEl = document.querySelector(
       '.react-flow__viewport',
     ) as HTMLElement | null;

--- a/src/client/src/InputDialog.tsx
+++ b/src/client/src/InputDialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { DIALOG_WIDTH, DIALOG_Z_INDEX } from './ConfirmDialog';
 
 type Props = {
   message: string;
@@ -41,7 +42,7 @@ export function InputDialog({
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        zIndex: 1000,
+        zIndex: DIALOG_Z_INDEX,
       }}
       onClick={onCancel}
       onKeyDown={(e) => {
@@ -56,7 +57,7 @@ export function InputDialog({
           background: '#fff',
           borderRadius: 8,
           padding: 24,
-          width: 380,
+          width: DIALOG_WIDTH,
           maxWidth: '90vw',
           boxShadow: '0 4px 24px rgba(0,0,0,0.2)',
         }}

--- a/src/client/src/SettingsPopup.tsx
+++ b/src/client/src/SettingsPopup.tsx
@@ -1,6 +1,8 @@
 import type { FileId, SheetId } from '@conversensus/shared';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+export const FLOATING_UI_Z_INDEX = 100;
+
 export type PopupTarget =
   | { type: 'file'; id: FileId }
   | { type: 'sheet'; fileId: FileId; sheetId: SheetId };
@@ -79,7 +81,7 @@ export function SettingsPopup({
         position: 'absolute',
         right: 8,
         top: 0,
-        zIndex: 100,
+        zIndex: FLOATING_UI_Z_INDEX,
         background: '#fff',
         border: '1px solid #ccc',
         borderRadius: 6,

--- a/src/client/src/Sidebar.tsx
+++ b/src/client/src/Sidebar.tsx
@@ -13,7 +13,7 @@ import {
 } from '@conversensus/shared';
 import { useRef, useState } from 'react';
 import { AlertDialog } from './AlertDialog';
-import type { Branch } from './atproto';
+import { BRANCH_STATUS, type Branch, TRUNK_PREFIX } from './atproto';
 import type { PopupTarget } from './SettingsPopup';
 import { SettingsPopup } from './SettingsPopup';
 
@@ -386,7 +386,7 @@ export function Sidebar({
                         {isActiveSheet &&
                           (() => {
                             const bs = (sheetBranches.get(s.id) ?? []).filter(
-                              (b) => b.name !== 'trunk',
+                              (b) => b.name !== TRUNK_PREFIX,
                             );
                             return (
                               <ul
@@ -399,8 +399,10 @@ export function Sidebar({
                                 {bs.map((branch) => {
                                   const isActiveBranch =
                                     activeBranchId === branch.id;
-                                  const isMerged = branch.status === 'merged';
-                                  const isClosed = branch.status === 'closed';
+                                  const isMerged =
+                                    branch.status === BRANCH_STATUS.MERGED;
+                                  const isClosed =
+                                    branch.status === BRANCH_STATUS.CLOSED;
                                   const bgColor = isActiveBranch
                                     ? '#dde8ff'
                                     : isMerged

--- a/src/client/src/atproto/branchState.ts
+++ b/src/client/src/atproto/branchState.ts
@@ -13,15 +13,27 @@
  */
 
 import type {
+  AtUri,
   CommitOperation,
+  Did,
   EdgeLayout,
   GraphEdge,
   GraphNode,
+  ISODateString,
   NodeLayout,
   Sheet,
   SheetId,
 } from '@conversensus/shared';
 import { currentDid } from './client';
+
+export const BRANCH_STATUS = {
+  CREATING: 'creating',
+  OPEN: 'open',
+  MERGED: 'merged',
+  CLOSED: 'closed',
+} as const;
+export type BranchStatus = (typeof BRANCH_STATUS)[keyof typeof BRANCH_STATUS];
+
 import {
   branches,
   commits,
@@ -65,24 +77,24 @@ export type Branch = {
   sheetId: SheetId;
   name: string;
   description?: string;
-  authorDid: string;
+  authorDid: Did;
   status: 'creating' | 'open' | 'merged' | 'closed';
-  baseCommitUri?: string;
-  createdAt: string;
-  uri: string;
+  baseCommitUri?: AtUri;
+  createdAt: ISODateString;
+  uri: AtUri;
   cid: string;
 };
 
 export type Commit = {
   id: string; // UUID (rkey)
   sheetId: SheetId;
-  branchUri: string;
+  branchUri: AtUri;
   message: string;
-  authorDid: string;
-  parentCommitUri?: string;
+  authorDid: Did;
+  parentCommitUri?: AtUri;
   operations: CommitOperation[];
-  createdAt: string;
-  uri: string;
+  createdAt: ISODateString;
+  uri: AtUri;
   cid: string;
 };
 
@@ -276,17 +288,17 @@ export async function createMainBranch(
   const authorDid = currentDid();
   const result = await deps.branches.put(branchId, {
     sheet: sheetRef,
-    name: 'trunk',
+    name: TRUNK_PREFIX,
     authorDid,
-    status: 'open',
+    status: BRANCH_STATUS.OPEN,
     createdAt: now,
   });
   return {
     id: branchId,
     sheetId,
-    name: 'trunk',
+    name: TRUNK_PREFIX,
     authorDid,
-    status: 'open',
+    status: BRANCH_STATUS.OPEN,
     createdAt: now,
     uri: result.uri,
     cid: result.cid,
@@ -406,7 +418,7 @@ export async function createBranch(
     sheet: sheetRef,
     name,
     authorDid,
-    status: 'creating',
+    status: BRANCH_STATUS.CREATING,
     ...(baseCommitRef && { baseCommit: baseCommitRef }),
     createdAt: now,
   });
@@ -485,7 +497,7 @@ export async function createBranch(
     sheet: sheetRef,
     name,
     authorDid,
-    status: 'open',
+    status: BRANCH_STATUS.OPEN,
     ...(baseCommitRef && { baseCommit: baseCommitRef }),
     createdAt: now,
   });
@@ -495,7 +507,7 @@ export async function createBranch(
     sheetId,
     name,
     authorDid,
-    status: 'open',
+    status: BRANCH_STATUS.OPEN,
     baseCommitUri: baseCommitRef?.uri,
     createdAt: now,
     uri: openResult.uri,

--- a/src/client/src/atproto/cidCache.ts
+++ b/src/client/src/atproto/cidCache.ts
@@ -1,3 +1,5 @@
+import type { ISODateString, Rkey } from '@conversensus/shared';
+
 /**
  * CID キャッシュ: PDS 上の各レコードの最終確認済み CID を追跡する。
  * - 書き込み時 (syncSheetToAtproto) → setCid で更新
@@ -5,18 +7,18 @@
  * - ポーリング時 (poller.ts) → 新 CID と比較してリモート変更を検出
  */
 
-type CacheEntry = { cid: string; createdAt?: string };
+type CacheEntry = { cid: string; createdAt?: ISODateString };
 const _cache = new Map<string, CacheEntry>(); // `${collection}/${rkey}` → entry
 
-function key(collection: string, rkey: string): string {
+function key(collection: string, rkey: Rkey): string {
   return `${collection}/${rkey}`;
 }
 
 export function setCid(
   collection: string,
-  rkey: string,
+  rkey: Rkey,
   cid: string,
-  createdAt?: string,
+  createdAt?: ISODateString,
 ): void {
   const existing = _cache.get(key(collection, rkey));
   _cache.set(key(collection, rkey), {
@@ -26,15 +28,15 @@ export function setCid(
   });
 }
 
-export function getCid(collection: string, rkey: string): string | undefined {
+export function getCid(collection: string, rkey: Rkey): string | undefined {
   return _cache.get(key(collection, rkey))?.cid;
 }
 
 /** PDS から読んだ createdAt を返す。なければ undefined */
 export function getCreatedAt(
   collection: string,
-  rkey: string,
-): string | undefined {
+  rkey: Rkey,
+): ISODateString | undefined {
   return _cache.get(key(collection, rkey))?.createdAt;
 }
 
@@ -42,7 +44,7 @@ export function getCreatedAt(
 export function cacheResult(
   uri: string,
   cid: string,
-  createdAt?: string,
+  createdAt?: ISODateString,
 ): void {
   // AT-URI: "at://did/collection/rkey"
   const parts = uri.split('/');

--- a/src/client/src/atproto/client.ts
+++ b/src/client/src/atproto/client.ts
@@ -1,7 +1,8 @@
 import { AtpAgent } from '@atproto/api';
+import type { Did } from '@conversensus/shared';
 
 export type AtprotoSession = {
-  did: string;
+  did: Did;
   handle: string;
 };
 
@@ -38,7 +39,7 @@ export async function login(
   }
 }
 
-export function currentDid(): string {
+export function currentDid(): Did {
   const did = getAgent().session?.did;
   if (!did)
     throw new Error('ATProto session not initialized. Call login() first.');

--- a/src/client/src/atproto/collectionTypes.ts
+++ b/src/client/src/atproto/collectionTypes.ts
@@ -1,18 +1,19 @@
+import type { AtUri, Rkey } from '@conversensus/shared';
 import type { RecordResult, StrongRef } from './types';
 
 /** PDS record with URI and CID */
 export type RecordEntry<T = unknown> = {
-  uri: string;
+  uri: AtUri;
   cid: string;
   value: T;
 };
 
 /** Minimal interface for repo-level record CRUD — what branchState needs from each collection */
 export interface CollectionCRUD<T = unknown> {
-  put(rkey: string, data: T): Promise<RecordResult>;
-  get(rkey: string): Promise<RecordEntry<T>>;
+  put(rkey: Rkey, data: T): Promise<RecordResult>;
+  get(rkey: Rkey): Promise<RecordEntry<T>>;
   list(): Promise<RecordEntry<T>[]>;
-  delete(rkey: string): Promise<void>;
+  delete(rkey: Rkey): Promise<void>;
 }
 
 /** Nodes / Edges / Layouts also support prefix listing */

--- a/src/client/src/atproto/collections.ts
+++ b/src/client/src/atproto/collections.ts
@@ -1,3 +1,4 @@
+import type { AtUri, Rkey } from '@conversensus/shared';
 import { currentDid, getAgent } from './client';
 import {
   type BranchRecord,
@@ -20,18 +21,18 @@ import {
 
 export const TRUNK_PREFIX = 'trunk';
 
-export function makeRkey(prefix: string, id: string): string {
+export function makeRkey(prefix: string, id: string): Rkey {
   return `${prefix}_${id}`;
 }
 
 // "trunk_uuid" → "uuid"、旧形式 "uuid" (プレフィックスなし) → "uuid" (後方互換)
-export function idFromRkey(rkey: string): string {
+export function idFromRkey(rkey: Rkey): string {
   const idx = rkey.indexOf('_');
   return idx >= 0 ? rkey.slice(idx + 1) : rkey;
 }
 
 // "trunk_uuid" → "trunk"、旧形式 "uuid" → TRUNK_PREFIX (後方互換)
-export function prefixFromRkey(rkey: string): string {
+export function prefixFromRkey(rkey: Rkey): string {
   const idx = rkey.indexOf('_');
   return idx >= 0 ? rkey.slice(0, idx) : TRUNK_PREFIX;
 }
@@ -40,7 +41,7 @@ export function prefixFromRkey(rkey: string): string {
 
 async function putRecord(
   collection: string,
-  rkey: string,
+  rkey: Rkey,
   record: Record<string, unknown>,
 ): Promise<RecordResult> {
   const res = await getAgent().api.com.atproto.repo.putRecord({
@@ -54,8 +55,8 @@ async function putRecord(
 
 async function getRecord(
   collection: string,
-  rkey: string,
-): Promise<{ uri: string; cid: string; value: unknown }> {
+  rkey: Rkey,
+): Promise<{ uri: AtUri; cid: string; value: unknown }> {
   const res = await getAgent().api.com.atproto.repo.getRecord({
     repo: currentDid(),
     collection,
@@ -66,8 +67,8 @@ async function getRecord(
 
 async function listRecords(
   collection: string,
-): Promise<Array<{ uri: string; cid: string; value: unknown }>> {
-  const all: Array<{ uri: string; cid: string; value: unknown }> = [];
+): Promise<Array<{ uri: AtUri; cid: string; value: unknown }>> {
+  const all: Array<{ uri: AtUri; cid: string; value: unknown }> = [];
   let cursor: string | undefined;
   do {
     const res = await getAgent().api.com.atproto.repo.listRecords({
@@ -82,7 +83,7 @@ async function listRecords(
   return all;
 }
 
-async function deleteRecord(collection: string, rkey: string): Promise<void> {
+async function deleteRecord(collection: string, rkey: Rkey): Promise<void> {
   await getAgent().api.com.atproto.repo.deleteRecord({
     repo: currentDid(),
     collection,
@@ -91,12 +92,12 @@ async function deleteRecord(collection: string, rkey: string): Promise<void> {
 }
 
 // rkey を AT-URI から取り出す: "at://did/collection/rkey" → "rkey"
-function rkeyFromUri(uri: string): string {
+function rkeyFromUri(uri: AtUri): string {
   return uri.split('/').at(-1) ?? uri;
 }
 
 // AT-URI を構築する
-function atUri(collection: string, rkey: string): string {
+function atUri(collection: string, rkey: Rkey): string {
   return `at://${currentDid()}/${collection}/${rkey}`;
 }
 
@@ -149,10 +150,10 @@ export const sheets = {
 // --- Node ---
 
 export const nodes = {
-  put(rkey: string, data: Omit<NodeRecord, '$type'>): Promise<RecordResult> {
+  put(rkey: Rkey, data: Omit<NodeRecord, '$type'>): Promise<RecordResult> {
     return putRecord(NSID.node, rkey, { $type: NSID.node, ...data });
   },
-  get(rkey: string) {
+  get(rkey: Rkey) {
     return getRecord(NSID.node, rkey);
   },
   list() {
@@ -162,14 +163,14 @@ export const nodes = {
     const all = await listRecords(NSID.node);
     return all.filter((r) => prefixFromRkey(rkeyFromUri(r.uri)) === prefix);
   },
-  delete(rkey: string) {
+  delete(rkey: Rkey) {
     return deleteRecord(NSID.node, rkey);
   },
-  async ref(rkey: string): Promise<StrongRef> {
+  async ref(rkey: Rkey): Promise<StrongRef> {
     const r = await getRecord(NSID.node, rkey);
     return { uri: r.uri, cid: r.cid };
   },
-  refFromResult(_rkey: string, result: RecordResult): StrongRef {
+  refFromResult(_rkey: Rkey, result: RecordResult): StrongRef {
     return { uri: result.uri, cid: result.cid };
   },
 };
@@ -177,10 +178,10 @@ export const nodes = {
 // --- Edge ---
 
 export const edges = {
-  put(rkey: string, data: Omit<EdgeRecord, '$type'>): Promise<RecordResult> {
+  put(rkey: Rkey, data: Omit<EdgeRecord, '$type'>): Promise<RecordResult> {
     return putRecord(NSID.edge, rkey, { $type: NSID.edge, ...data });
   },
-  get(rkey: string) {
+  get(rkey: Rkey) {
     return getRecord(NSID.edge, rkey);
   },
   list() {
@@ -190,7 +191,7 @@ export const edges = {
     const all = await listRecords(NSID.edge);
     return all.filter((r) => prefixFromRkey(rkeyFromUri(r.uri)) === prefix);
   },
-  delete(rkey: string) {
+  delete(rkey: Rkey) {
     return deleteRecord(NSID.edge, rkey);
   },
 };
@@ -199,7 +200,7 @@ export const edges = {
 
 export const nodeLayouts = {
   put(
-    rkey: string,
+    rkey: Rkey,
     data: Omit<NodeLayoutRecord, '$type'>,
   ): Promise<RecordResult> {
     return putRecord(NSID.nodeLayout, rkey, {
@@ -207,7 +208,7 @@ export const nodeLayouts = {
       ...data,
     });
   },
-  get(rkey: string) {
+  get(rkey: Rkey) {
     return getRecord(NSID.nodeLayout, rkey);
   },
   list() {
@@ -217,7 +218,7 @@ export const nodeLayouts = {
     const all = await listRecords(NSID.nodeLayout);
     return all.filter((r) => prefixFromRkey(rkeyFromUri(r.uri)) === prefix);
   },
-  delete(rkey: string) {
+  delete(rkey: Rkey) {
     return deleteRecord(NSID.nodeLayout, rkey);
   },
 };
@@ -226,7 +227,7 @@ export const nodeLayouts = {
 
 export const edgeLayouts = {
   put(
-    rkey: string,
+    rkey: Rkey,
     data: Omit<EdgeLayoutRecord, '$type'>,
   ): Promise<RecordResult> {
     return putRecord(NSID.edgeLayout, rkey, {
@@ -234,7 +235,7 @@ export const edgeLayouts = {
       ...data,
     });
   },
-  get(rkey: string) {
+  get(rkey: Rkey) {
     return getRecord(NSID.edgeLayout, rkey);
   },
   list() {
@@ -244,7 +245,7 @@ export const edgeLayouts = {
     const all = await listRecords(NSID.edgeLayout);
     return all.filter((r) => prefixFromRkey(rkeyFromUri(r.uri)) === prefix);
   },
-  delete(rkey: string) {
+  delete(rkey: Rkey) {
     return deleteRecord(NSID.edgeLayout, rkey);
   },
 };

--- a/src/client/src/atproto/index.ts
+++ b/src/client/src/atproto/index.ts
@@ -1,5 +1,7 @@
 export {
+  BRANCH_STATUS,
   type Branch,
+  type BranchStatus,
   type Commit,
   computeOperations,
   createBranch,

--- a/src/client/src/atproto/mapper.ts
+++ b/src/client/src/atproto/mapper.ts
@@ -14,6 +14,7 @@ import type {
   GraphFile,
   GraphNode,
   NodeLayout,
+  Rkey,
   Sheet,
 } from '@conversensus/shared';
 import {
@@ -145,7 +146,7 @@ export function edgeLayoutToRecord(
 
 // --- ATProto レコード → ドメイン ---
 
-export function recordToNode(rkey: string, record: NodeRecord): GraphNode {
+export function recordToNode(rkey: Rkey, record: NodeRecord): GraphNode {
   return {
     id: NodeIdSchema.parse(idFromRkey(rkey)),
     content: record.content,
@@ -159,7 +160,7 @@ export function recordToNode(rkey: string, record: NodeRecord): GraphNode {
   };
 }
 
-export function recordToEdge(rkey: string, record: EdgeRecord): GraphEdge {
+export function recordToEdge(rkey: Rkey, record: EdgeRecord): GraphEdge {
   return {
     id: EdgeIdSchema.parse(idFromRkey(rkey)),
     source: NodeIdSchema.parse(idFromRkey(rkeyFromUri(record.source.uri))),
@@ -172,7 +173,7 @@ export function recordToEdge(rkey: string, record: EdgeRecord): GraphEdge {
 }
 
 export function recordToNodeLayout(
-  rkey: string,
+  rkey: Rkey,
   record: NodeLayoutRecord,
 ): NodeLayout {
   return {
@@ -185,7 +186,7 @@ export function recordToNodeLayout(
 }
 
 export function recordToEdgeLayout(
-  rkey: string,
+  rkey: Rkey,
   record: EdgeLayoutRecord,
 ): EdgeLayout {
   return {
@@ -207,7 +208,7 @@ export function recordToEdgeLayout(
 }
 
 export function recordToSheetMeta(
-  rkey: string,
+  rkey: Rkey,
   record: SheetRecord,
 ): Pick<Sheet, 'id' | 'name' | 'description'> {
   return {
@@ -220,7 +221,7 @@ export function recordToSheetMeta(
 }
 
 export function recordToFileMeta(
-  rkey: string,
+  rkey: Rkey,
   record: FileRecord,
 ): Pick<GraphFile, 'id' | 'name' | 'description'> & { id: FileId } {
   return {

--- a/src/client/src/atproto/types.ts
+++ b/src/client/src/atproto/types.ts
@@ -1,5 +1,7 @@
+import type { AtUri, Did, ISODateString, Rkey } from '@conversensus/shared';
+
 // ATProto strongRef: uri (AT-URI) + cid (content hash)
-export type StrongRef = { uri: string; cid: string };
+export type StrongRef = { uri: AtUri; cid: string };
 
 // Lexicon NSID 定数
 export const NSID = {
@@ -18,7 +20,7 @@ export type FileRecord = {
   $type: typeof NSID.file;
   name: string;
   description?: string;
-  createdAt: string;
+  createdAt: ISODateString;
 };
 
 export type SheetRecord = {
@@ -26,7 +28,7 @@ export type SheetRecord = {
   name: string;
   description?: string;
   file?: StrongRef; // 親ファイルへの参照 (後方互換のため optional)
-  createdAt: string;
+  createdAt: ISODateString;
 };
 
 export type NodeRecord = {
@@ -36,7 +38,7 @@ export type NodeRecord = {
   properties?: unknown;
   nodeType?: 'group';
   parent?: StrongRef;
-  createdAt: string;
+  createdAt: ISODateString;
 };
 
 export type EdgeRecord = {
@@ -46,7 +48,7 @@ export type EdgeRecord = {
   target: StrongRef;
   label?: string;
   properties?: unknown;
-  createdAt: string;
+  createdAt: ISODateString;
 };
 
 export type NodeLayoutRecord = {
@@ -56,7 +58,7 @@ export type NodeLayoutRecord = {
   y?: number;
   width?: number;
   height?: number;
-  createdAt: string;
+  createdAt: ISODateString;
 };
 
 export type EdgeLayoutRecord = {
@@ -67,15 +69,15 @@ export type EdgeLayoutRecord = {
   pathType?: 'bezier' | 'straight' | 'step' | 'smoothstep';
   labelOffsetX?: number;
   labelOffsetY?: number;
-  createdAt: string;
+  createdAt: ISODateString;
 };
 
-export type RecordResult = { uri: string; cid: string };
+export type RecordResult = { uri: AtUri; cid: string };
 
 /** ポーリングで検出されたリモート変更 */
 export type RemoteChange = {
   collection: string; // NSID (例: "app.conversensus.graph.node")
-  rkey: string; // レコードキー (例: nodeId)
+  rkey: Rkey; // レコードキー (例: nodeId)
   cid: string; // 新しい CID
   value: unknown; // PDS 上の最新レコード値
   changeType: 'add' | 'update'; // 新規追加 or 既存変更
@@ -86,10 +88,10 @@ export type BranchRecord = {
   sheet: StrongRef;
   name: string;
   description?: string;
-  authorDid: string;
+  authorDid: Did;
   status: 'creating' | 'open' | 'merged' | 'closed';
   baseCommit?: StrongRef;
-  createdAt: string;
+  createdAt: ISODateString;
 };
 
 export type CommitRecord = {
@@ -97,11 +99,11 @@ export type CommitRecord = {
   sheet: StrongRef;
   branch: StrongRef;
   message: string;
-  authorDid: string;
+  authorDid: Did;
   parentCommit?: StrongRef;
   operations: unknown[]; // CommitOperation[] を JSON として格納
   tree?: StrongRef[]; // commit 時点の Node/Edge レコードへの参照 (snapshot)
-  createdAt: string;
+  createdAt: ISODateString;
 };
 
 export type MergeRecord = {
@@ -109,7 +111,7 @@ export type MergeRecord = {
   sheet: StrongRef;
   branch: StrongRef;
   message: string;
-  authorDid: string;
+  authorDid: Did;
   commit?: StrongRef;
-  createdAt: string;
+  createdAt: ISODateString;
 };

--- a/src/client/src/events/GraphEvent.ts
+++ b/src/client/src/events/GraphEvent.ts
@@ -8,6 +8,8 @@ import type {
   NodeLayout,
 } from '@conversensus/shared';
 
+export const LOCAL_USER_ID = 'local';
+
 type Position = { x: number; y: number };
 type Size = { width: number; height: number };
 type EdgeStyle = { pathType?: EdgePathType } & Record<string, unknown>;
@@ -205,7 +207,7 @@ export function makeEventBase<C extends GraphEvent['category']>(
   return {
     id: crypto.randomUUID(),
     timestamp: Date.now(),
-    userId: 'local',
+    userId: LOCAL_USER_ID,
     category,
   };
 }

--- a/src/client/src/graphTransform.ts
+++ b/src/client/src/graphTransform.ts
@@ -12,6 +12,13 @@ import { type Edge, MarkerType, type Node } from '@xyflow/react';
 export const DEFAULT_NODE_STYLE = { width: 160, height: 80 };
 export const GROUP_PADDING = 20;
 export const GROUP_TITLE_HEIGHT = 30;
+export const GROUP_NODE_TYPE = 'group' as const;
+export const PNG_EXPORT_WIDTH = 1920;
+export const PNG_EXPORT_HEIGHT = 1080;
+export const PNG_EXPORT_MIN_ZOOM = 0.5;
+export const PNG_EXPORT_MAX_ZOOM = 2;
+export const PNG_EXPORT_PADDING = 0.1;
+export const DEFAULT_EDGE_PATH_TYPE = 'bezier' as const;
 
 export function toFlowNodes(
   nodes: GraphNode[],
@@ -35,7 +42,7 @@ export function toFlowNodes(
         label: n.content,
         conflicted: conflictedNodeIds?.has(n.id) ?? false,
       },
-      type: n.nodeType === 'group' ? 'groupNode' : 'editableNode',
+      type: n.nodeType === GROUP_NODE_TYPE ? 'groupNode' : 'editableNode',
       parentId: n.parentId,
       style:
         layout.width !== undefined || layout.height !== undefined
@@ -94,7 +101,7 @@ export function toFlowEdges(
       markerEnd: { type: MarkerType.ArrowClosed },
       style: conflicted ? { stroke: '#f97316', strokeWidth: 3 } : undefined,
       data: {
-        pathType: layout?.pathType ?? 'bezier',
+        pathType: layout?.pathType ?? DEFAULT_EDGE_PATH_TYPE,
         labelOffsetX: layout?.labelOffsetX ?? 0,
         labelOffsetY: layout?.labelOffsetY ?? 0,
         conflicted,
@@ -111,7 +118,7 @@ export function fromFlowNodes(nodes: Node[]): {
   const graphNodes: GraphNode[] = nodes.map((n) => ({
     id: n.id as NodeId,
     content: String(n.data.label ?? ''),
-    ...(n.type === 'groupNode' ? { nodeType: 'group' as const } : {}),
+    ...(n.type === 'groupNode' ? { nodeType: GROUP_NODE_TYPE } : {}),
     ...(n.parentId ? { parentId: n.parentId as NodeId } : {}),
   }));
 

--- a/src/client/src/hooks/useBranchOperations.ts
+++ b/src/client/src/hooks/useBranchOperations.ts
@@ -1,6 +1,7 @@
 import type { GraphFile, Sheet, SheetId } from '@conversensus/shared';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
+  BRANCH_STATUS,
   type Branch,
   computeOperations,
   createBranch,
@@ -101,7 +102,7 @@ export function useBranchOperations({
   const preBranchFile = useRef<GraphFile | null>(null);
   const latestCommitRef = useRef<{ uri: string; cid: string } | null>(null);
 
-  const isTrunk = !activeBranch || activeBranch.name === 'trunk';
+  const isTrunk = !activeBranch || activeBranch.name === TRUNK_PREFIX;
 
   const [branchDiffNodeIds, branchDiffEdgeIds] = useMemo(() => {
     if (isTrunk || !branchOriginalBase || !activeSheet) {
@@ -122,7 +123,7 @@ export function useBranchOperations({
       isTrunk ||
       !lastCommitBase ||
       !activeSheet ||
-      activeBranch?.status !== 'open'
+      activeBranch?.status !== BRANCH_STATUS.OPEN
     )
       return [];
     return deps.computeOperations(lastCommitBase, activeSheet);
@@ -148,7 +149,7 @@ export function useBranchOperations({
     async (sheetId: SheetId, branch: Branch | null) => {
       latestCommitRef.current = null;
 
-      if (!branch || branch.name === 'trunk') {
+      if (!branch || branch.name === TRUNK_PREFIX) {
         setActiveBranch(branch);
         setLastCommitBase(null);
         setBranchOriginalBase(null);
@@ -170,7 +171,7 @@ export function useBranchOperations({
         preBranchFile.current = activeFile ?? null;
 
         let originalBase: typeof branchSheet;
-        if (branch.status === 'merged') {
+        if (branch.status === BRANCH_STATUS.MERGED) {
           originalBase = await deps.fetchBranchSheetFromPds(
             deps.TRUNK_PREFIX,
             sheetId,
@@ -183,7 +184,7 @@ export function useBranchOperations({
           }
         }
         setBranchOriginalBase(originalBase);
-        if (branch.status === 'open') {
+        if (branch.status === BRANCH_STATUS.OPEN) {
           const storedLastBase = lastCommitBaseMap.current.get(branch.uri);
           if (storedLastBase) {
             setLastCommitBase(storedLastBase);
@@ -209,7 +210,9 @@ export function useBranchOperations({
           });
         }
 
-        setNewCommitsSinceMerge(branch.status === 'merged' ? 0 : cs.length);
+        setNewCommitsSinceMerge(
+          branch.status === BRANCH_STATUS.MERGED ? 0 : cs.length,
+        );
         setActiveBranch(branch);
       } catch (err) {
         console.warn('[branch] select failed:', err);
@@ -271,7 +274,10 @@ export function useBranchOperations({
 
         await deps.mergeBranchToTrunk(branch, activeSheetId, sheetRef);
         await deps.createMergeRecord(branch, sheetRef, branchRef, latestCommit);
-        const mergedBranch = await deps.updateBranchStatus(branch, 'merged');
+        const mergedBranch = await deps.updateBranchStatus(
+          branch,
+          BRANCH_STATUS.MERGED,
+        );
 
         setSheetBranches((prev) => {
           const next = new Map(prev);
@@ -324,7 +330,10 @@ export function useBranchOperations({
       });
       if (!ok) return;
       try {
-        const closedBranch = await deps.updateBranchStatus(branch, 'closed');
+        const closedBranch = await deps.updateBranchStatus(
+          branch,
+          BRANCH_STATUS.CLOSED,
+        );
         setSheetBranches((prev) => {
           const next = new Map(prev);
           const sheetId = branch.sheetId;

--- a/src/client/src/hooks/useEdgeContextMenu.ts
+++ b/src/client/src/hooks/useEdgeContextMenu.ts
@@ -4,6 +4,7 @@ import type { MouseEvent } from 'react';
 import { useCallback, useEffect, useState } from 'react';
 import type { GraphEvent } from '../events/GraphEvent';
 import { makeEventBase } from '../events/GraphEvent';
+import { DEFAULT_EDGE_PATH_TYPE } from '../graphTransform';
 
 const CONTEXT_MENU_WIDTH = 160;
 const CONTEXT_MENU_HEIGHT = 185; // header + 4 items の概算
@@ -36,7 +37,9 @@ export function useEdgeContextMenu(
       const targetEdgeIds = targets.map((ed) => ed.id);
 
       const types = targets.map(
-        (ed) => (ed.data?.pathType as EdgePathType | undefined) ?? 'bezier',
+        (ed) =>
+          (ed.data?.pathType as EdgePathType | undefined) ??
+          DEFAULT_EDGE_PATH_TYPE,
       );
       const currentPathType = types.every((t) => t === types[0])
         ? types[0]
@@ -58,7 +61,8 @@ export function useEdgeContextMenu(
       for (const edgeId of targetEdgeIds) {
         const edge = currentEdges.find((e) => e.id === edgeId);
         const fromPathType =
-          (edge?.data?.pathType as EdgePathType | undefined) ?? 'bezier';
+          (edge?.data?.pathType as EdgePathType | undefined) ??
+          DEFAULT_EDGE_PATH_TYPE;
         dispatch({
           ...makeEventBase('presentation'),
           type: 'EDGE_STYLE_CHANGED',

--- a/src/client/src/hooks/useGroupNodes.ts
+++ b/src/client/src/hooks/useGroupNodes.ts
@@ -5,6 +5,7 @@ import type { GraphEvent } from '../events/GraphEvent';
 import { makeEventBase } from '../events/GraphEvent';
 import {
   DEFAULT_NODE_STYLE,
+  GROUP_NODE_TYPE,
   GROUP_PADDING,
   GROUP_TITLE_HEIGHT,
 } from '../graphTransform';
@@ -54,7 +55,7 @@ export function useGroupNodes(
     const parentData: GraphNode = {
       id: parentId,
       content: 'グループ',
-      nodeType: 'group',
+      nodeType: GROUP_NODE_TYPE,
       ...(sharedParentId ? { parentId: sharedParentId as NodeId } : {}),
     };
 

--- a/src/server/src/index.ts
+++ b/src/server/src/index.ts
@@ -24,6 +24,13 @@ const LOCALHOST_ORIGIN_PREFIX = 'http://localhost:';
 const DEFAULT_FILE_NAME = '無題';
 const DEFAULT_SHEET_NAME = 'Sheet 1';
 
+const _HTTP_OK = 200;
+const HTTP_CREATED = 201;
+const HTTP_NO_CONTENT = 204;
+const HTTP_BAD_REQUEST = 400;
+const HTTP_NOT_FOUND = 404;
+const HTTP_INTERNAL_SERVER_ERROR = 500;
+
 const app = new Hono();
 
 app.use(
@@ -36,7 +43,7 @@ app.use(
 
 app.onError((err, c) => {
   console.error(err);
-  return c.json({ error: 'Internal server error' }, 500);
+  return c.json({ error: 'Internal server error' }, HTTP_INTERNAL_SERVER_ERROR);
 });
 
 // GET /files - ファイル一覧
@@ -50,7 +57,7 @@ app.post('/files', async (c) => {
   const raw = await c.req.json().catch(() => null);
   const parsed = CreateFileRequestSchema.safeParse(raw);
   if (!parsed.success) {
-    return c.json({ error: parsed.error.flatten() }, 400);
+    return c.json({ error: parsed.error.flatten() }, HTTP_BAD_REQUEST);
   }
   const body = parsed.data;
   const id = randomUUID() as FileId;
@@ -68,13 +75,13 @@ app.post('/files', async (c) => {
     ],
   };
   await writeFile(data);
-  return c.json(data, 201);
+  return c.json(data, HTTP_CREATED);
 });
 
 // GET /files/:id - ファイル取得
 app.get('/files/:id', async (c) => {
   const data = await readFile(c.req.param('id'));
-  if (!data) return c.json({ error: 'Not found' }, 404);
+  if (!data) return c.json({ error: 'Not found' }, HTTP_NOT_FOUND);
   return c.json(data);
 });
 
@@ -82,11 +89,11 @@ app.get('/files/:id', async (c) => {
 app.put('/files/:id', async (c) => {
   const id = c.req.param('id');
   const existing = await readFile(id);
-  if (!existing) return c.json({ error: 'Not found' }, 404);
+  if (!existing) return c.json({ error: 'Not found' }, HTTP_NOT_FOUND);
   const raw = await c.req.json().catch(() => null);
   const parsed = UpdateFileRequestSchema.safeParse(raw);
   if (!parsed.success) {
-    return c.json({ error: parsed.error.flatten() }, 400);
+    return c.json({ error: parsed.error.flatten() }, HTTP_BAD_REQUEST);
   }
   const data: GraphFile = { ...parsed.data, id: existing.id };
   await writeFile(data);
@@ -121,14 +128,14 @@ app.post('/files/import', async (c) => {
             migrateV3toV4(migrateV2toV3(migrateV1toV2(parsedV1.data))),
           );
         } else {
-          return c.json({ error: parsedV4.error.flatten() }, 400);
+          return c.json({ error: parsedV4.error.flatten() }, HTTP_BAD_REQUEST);
         }
       }
     }
   }
 
   if (!parsedFile.success) {
-    return c.json({ error: parsedFile.error.flatten() }, 400);
+    return c.json({ error: parsedFile.error.flatten() }, HTTP_BAD_REQUEST);
   }
 
   const { version: _, ...fileData } = parsedFile.data;
@@ -173,14 +180,14 @@ app.post('/files/import', async (c) => {
     }),
   };
   await writeFile(data);
-  return c.json(data, 201);
+  return c.json(data, HTTP_CREATED);
 });
 
 // DELETE /files/:id - ファイル削除
 app.delete('/files/:id', async (c) => {
   const ok = await deleteFile(c.req.param('id'));
-  if (!ok) return c.json({ error: 'Not found' }, 404);
-  return c.body(null, 204);
+  if (!ok) return c.json({ error: 'Not found' }, HTTP_NOT_FOUND);
+  return c.body(null, HTTP_NO_CONTENT);
 });
 
 export default {

--- a/src/shared/src/migrations.ts
+++ b/src/shared/src/migrations.ts
@@ -1,10 +1,12 @@
 import { z } from 'zod';
 import {
+  CONVERSENSUS_FILE_VERSION,
   type ConversensusFile,
   EdgeIdSchema,
   EdgeLayoutSchema,
   EdgePathTypeSchema,
   FileIdSchema,
+  GROUP_NODE_TYPE,
   GraphEdgeSchema,
   GraphFileSchema,
   GraphNodeSchema,
@@ -16,6 +18,10 @@ import {
   StyleSchema,
 } from './schemas';
 
+const FILE_VERSION_V1 = '1' as const;
+const FILE_VERSION_V2 = '2' as const;
+const FILE_VERSION_V3 = '3' as const;
+
 // --- v1 互換スキーマ (マイグレーション専用) ---
 
 // v1 ノードスタイル: 座標・サイズ・グループ種別を直接持つ (v2 で NodeLayout に分離)
@@ -25,7 +31,7 @@ const NodeStyleSchema = z
     y: z.number().optional(),
     width: z.union([z.number(), z.string()]).optional(),
     height: z.union([z.number(), z.string()]).optional(),
-    nodeType: z.literal('group').optional(),
+    nodeType: z.literal(GROUP_NODE_TYPE).optional(),
   })
   .catchall(z.unknown());
 
@@ -67,7 +73,7 @@ const GraphFileV1Schema = z.object({
 });
 
 export const ConversensusFileV1Schema = GraphFileV1Schema.extend({
-  version: z.literal('1' as const),
+  version: z.literal(FILE_VERSION_V1),
 });
 export type ConversensusFileV1 = z.infer<typeof ConversensusFileV1Schema>;
 
@@ -87,7 +93,7 @@ const GraphFileV2Schema = GraphFileSchema.extend({
 });
 
 export const ConversensusFileV2Schema = GraphFileV2Schema.extend({
-  version: z.literal('2'),
+  version: z.literal(FILE_VERSION_V2),
 });
 export type ConversensusFileV2 = z.infer<typeof ConversensusFileV2Schema>;
 
@@ -108,7 +114,7 @@ const NodeLayoutV3Schema = z
     y: z.number().optional(),
     width: z.union([z.number(), z.string()]).optional(),
     height: z.union([z.number(), z.string()]).optional(),
-    nodeType: z.literal('group').optional(),
+    nodeType: z.literal(GROUP_NODE_TYPE).optional(),
     parentId: NodeIdSchema.optional(),
   })
   .catchall(z.unknown());
@@ -131,7 +137,7 @@ const GraphFileV3Schema = z.object({
 });
 
 export const ConversensusFileV3Schema = GraphFileV3Schema.extend({
-  version: z.literal('3'),
+  version: z.literal(FILE_VERSION_V3),
 });
 export type ConversensusFileV3 = z.infer<typeof ConversensusFileV3Schema>;
 
@@ -141,7 +147,7 @@ export type ConversensusFileV3 = z.infer<typeof ConversensusFileV3Schema>;
 export function migrateV1toV2(file: ConversensusFileV1): ConversensusFileV2 {
   return {
     ...file,
-    version: '2',
+    version: FILE_VERSION_V2,
     sheets: file.sheets.map((sheet) => {
       const layouts = sheet.nodes
         .filter((n) => n.style !== undefined)
@@ -206,7 +212,7 @@ export function migrateV1toV2(file: ConversensusFileV1): ConversensusFileV2 {
 export function migrateV3toV4(file: ConversensusFileV3): ConversensusFile {
   return {
     ...file,
-    version: '4',
+    version: CONVERSENSUS_FILE_VERSION,
     sheets: file.sheets.map((sheet) => {
       // レイアウトから nodeType と parentId を収集
       const nodeMetaMap = new Map<
@@ -241,7 +247,7 @@ export function migrateV3toV4(file: ConversensusFileV3): ConversensusFile {
 export function migrateV2toV3(file: ConversensusFileV2): ConversensusFile {
   return {
     ...file,
-    version: '3',
+    version: FILE_VERSION_V3,
     sheets: file.sheets.map((sheet) => {
       // ノードの parentId を nodeId → parentId のマップとして収集
       const nodeParentMap = new Map<string, NodeId>(

--- a/src/shared/src/schemas.ts
+++ b/src/shared/src/schemas.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+export const GROUP_NODE_TYPE = 'group' as const;
+
 // --- Branded ID schemas (UUID enforced at API boundaries) ---
 export const NodeIdSchema = z.string().uuid().brand<'NodeId'>();
 export const EdgeIdSchema = z.string().uuid().brand<'EdgeId'>();
@@ -18,6 +20,10 @@ export type EdgeLabel = string;
 export type FileName = string;
 export type FileDescription = string;
 export type SheetName = string;
+export type ISODateString = string;
+export type AtUri = string;
+export type Rkey = string;
+export type Did = string;
 
 // --- Compound type schemas ---
 export const StyleSchema = z.record(z.string(), z.unknown());
@@ -41,7 +47,7 @@ export const GraphNodeSchema = z.object({
   id: NodeIdSchema,
   content: z.string(),
   properties: z.record(z.string(), z.unknown()).optional(),
-  nodeType: z.literal('group').optional(),
+  nodeType: z.literal(GROUP_NODE_TYPE).optional(),
   parentId: NodeIdSchema.optional(),
 });
 
@@ -120,7 +126,7 @@ export const CommitOperationSchema = z.discriminatedUnion('op', [
     nodeId: z.string().uuid(),
     content: z.string(),
     properties: z.record(z.string(), z.unknown()).optional(),
-    nodeType: z.literal('group').optional(),
+    nodeType: z.literal(GROUP_NODE_TYPE).optional(),
     parentId: z.string().uuid().optional(),
   }),
   z.object({


### PR DESCRIPTION
## Summary

### ANA-86: 原始型に意味的エイリアス
- `ISODateString`, `AtUri`, `Rkey`, `Did` を `schemas.ts` に定義
- types, mapper, collections, client, cidCache, branchState の ~100箇所に適用

### ANA-87: マジックリテラルを定数化
- `BRANCH_STATUS` 定数オブジェクト (open/closed/merged/creating)
- Z-index 定数、ダイアログ幅、PNG export 定数
- HTTP ステータスコード定数
- `DEFAULT_EDGE_PATH_TYPE`, `GROUP_NODE_TYPE`, `LOCAL_USER_ID`
- ファイルバージョン定数、`TRUNK_PREFIX` 活用

### 26 files changed

## Test plan
- [x] lint / typecheck パス
- [x] 286 tests pass (0 fail)

Closes ANA-86, ANA-87

🤖 Generated with [Claude Code](https://claude.com/claude-code)