### PR TITLE
feat(lexicon): file/branch/commit/merge の lexicon JSON を追加 (ANA-61)

### DIFF
--- a/lexicons/app/conversensus/graph/branch.json
+++ b/lexicons/app/conversensus/graph/branch.json
@@ -1,0 +1,52 @@
+{
+  "lexicon": 1,
+  "id": "app.conversensus.graph.branch",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "A branch on a sheet. rkey = BranchId (UUID). Tracks open/merged/closed status and the base commit at branch creation.",
+      "key": "any",
+      "record": {
+        "type": "object",
+        "required": ["sheet", "name", "authorDid", "status", "createdAt"],
+        "properties": {
+          "sheet": {
+            "type": "ref",
+            "ref": "com.atproto.repo.strongRef",
+            "description": "The sheet this branch belongs to."
+          },
+          "name": {
+            "type": "string",
+            "maxLength": 256,
+            "description": "Display name of the branch."
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 2048,
+            "description": "Optional description of the branch."
+          },
+          "authorDid": {
+            "type": "string",
+            "format": "did",
+            "description": "DID of the user who created the branch."
+          },
+          "status": {
+            "type": "string",
+            "knownValues": ["creating", "open", "merged", "closed"],
+            "description": "Lifecycle status of the branch."
+          },
+          "baseCommit": {
+            "type": "ref",
+            "ref": "com.atproto.repo.strongRef",
+            "description": "The trunk commit that was the base when this branch was created."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Timestamp of record creation (ISO 8601)."
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/app/conversensus/graph/commit.json
+++ b/lexicons/app/conversensus/graph/commit.json
@@ -1,0 +1,59 @@
+{
+  "lexicon": 1,
+  "id": "app.conversensus.graph.commit",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "A commit on a branch. rkey = CommitId (UUID). Stores the operation list and optionally a snapshot of node/edge records at commit time.",
+      "key": "any",
+      "record": {
+        "type": "object",
+        "required": ["sheet", "branch", "message", "authorDid", "operations", "createdAt"],
+        "properties": {
+          "sheet": {
+            "type": "ref",
+            "ref": "com.atproto.repo.strongRef",
+            "description": "The sheet this commit applies to."
+          },
+          "branch": {
+            "type": "ref",
+            "ref": "com.atproto.repo.strongRef",
+            "description": "The branch this commit belongs to."
+          },
+          "message": {
+            "type": "string",
+            "maxLength": 1000,
+            "description": "Commit message."
+          },
+          "authorDid": {
+            "type": "string",
+            "format": "did",
+            "description": "DID of the commit author."
+          },
+          "parentCommit": {
+            "type": "ref",
+            "ref": "com.atproto.repo.strongRef",
+            "description": "The preceding commit on this branch, if any."
+          },
+          "operations": {
+            "type": "unknown",
+            "description": "Serialized CommitOperation[] describing the graph changes in this commit."
+          },
+          "tree": {
+            "type": "array",
+            "items": {
+              "type": "ref",
+              "ref": "com.atproto.repo.strongRef"
+            },
+            "description": "Snapshot of node/edge record refs at commit time."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Timestamp of record creation (ISO 8601)."
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/app/conversensus/graph/file.json
+++ b/lexicons/app/conversensus/graph/file.json
@@ -1,0 +1,32 @@
+{
+  "lexicon": 1,
+  "id": "app.conversensus.graph.file",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "A conversensus file that groups sheets. rkey = FileId (UUID).",
+      "key": "any",
+      "record": {
+        "type": "object",
+        "required": ["name", "createdAt"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 256,
+            "description": "Display name of the file."
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 2048,
+            "description": "Optional description of the file."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Timestamp of record creation (ISO 8601)."
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/app/conversensus/graph/merge.json
+++ b/lexicons/app/conversensus/graph/merge.json
@@ -1,0 +1,47 @@
+{
+  "lexicon": 1,
+  "id": "app.conversensus.graph.merge",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "A merge record created when a branch is merged into trunk. rkey = MergeId (UUID).",
+      "key": "any",
+      "record": {
+        "type": "object",
+        "required": ["sheet", "branch", "message", "authorDid", "createdAt"],
+        "properties": {
+          "sheet": {
+            "type": "ref",
+            "ref": "com.atproto.repo.strongRef",
+            "description": "The sheet that was merged into."
+          },
+          "branch": {
+            "type": "ref",
+            "ref": "com.atproto.repo.strongRef",
+            "description": "The branch that was merged."
+          },
+          "message": {
+            "type": "string",
+            "maxLength": 1000,
+            "description": "Merge message."
+          },
+          "authorDid": {
+            "type": "string",
+            "format": "did",
+            "description": "DID of the user who performed the merge."
+          },
+          "commit": {
+            "type": "ref",
+            "ref": "com.atproto.repo.strongRef",
+            "description": "The last branch commit included in this merge, if any."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Timestamp of record creation (ISO 8601)."
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 概要

`types.ts` に TypeScript 型として定義されていた以下の4レコード型に対応する lexicon JSON が未定義だったため追加した。

| NSID | 追加ファイル |
| -- | -- |
| `app.conversensus.graph.file` | `lexicons/.../file.json` |
| `app.conversensus.graph.branch` | `lexicons/.../branch.json` |
| `app.conversensus.graph.commit` | `lexicons/.../commit.json` |
| `app.conversensus.graph.merge` | `lexicons/.../merge.json` |

PDS はスキーマ検証なしにレコードを受け付けるため動作は既にしているが、ATProto の設計思想では lexicon がレコード型の正式な契約であるため、既存の `sheet`, `node`, `edge`, `nodeLayout`, `edgeLayout` と同様に定義した。

## 設計メモ

- `CommitRecord.operations` (`unknown[]`) は ATProto lexicon の `"type": "unknown"` で表現（CommitOperation[] を opaque JSON として格納するため）
- `CommitRecord.tree` は `strongRef` の配列として定義
- `BranchRecord.status` は `knownValues` で `creating / open / merged / closed` を列挙
- `authorDid` は `"format": "did"` を指定

## テスト

機能変更なし（lexicon JSON の追加のみ）。既存テスト 286 件すべてパス。

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)