### PR TITLE
ダブルクリックでノード種類を選ぶポップアップメニューを追加

### DIFF
--- a/src/client/src/GraphEditor.tsx
+++ b/src/client/src/GraphEditor.tsx
@@ -43,12 +43,15 @@ import {
   DEFAULT_NODE_STYLE,
   fromFlowEdges,
   fromFlowNodes,
+  GROUP_NODE_TYPE,
+  IMAGE_NODE_TYPE,
   PNG_EXPORT_HEIGHT,
   PNG_EXPORT_MAX_ZOOM,
   PNG_EXPORT_MIN_ZOOM,
   PNG_EXPORT_PADDING,
   PNG_EXPORT_WIDTH,
   RF_GROUP_NODE_TYPE,
+  RF_IMAGE_NODE_TYPE,
   toFlowEdges,
   toFlowNodes,
 } from './graphTransform';
@@ -57,6 +60,8 @@ import { useEdgeContextMenu } from './hooks/useEdgeContextMenu';
 import { type UndoState, useEventStore } from './hooks/useEventStore';
 import { useGroupNodes } from './hooks/useGroupNodes';
 import { usePaneDoubleClick } from './hooks/usePaneDoubleClick';
+import type { NodeTypeOption } from './NodeTypeMenu';
+import { NodeTypeMenu } from './NodeTypeMenu';
 
 const RF_INIT_DELAY_MS = 150;
 const DROP_TARGET_ATTR = 'data-drop-target'; // グループへ追加しようとしている
@@ -233,7 +238,11 @@ function GraphEditorInner({
   }, [nodes, edges]);
 
   const nodeTypes = useMemo(
-    () => ({ editableNode: EditableNode, [RF_GROUP_NODE_TYPE]: GroupNode }),
+    () => ({
+      editableNode: EditableNode,
+      [RF_GROUP_NODE_TYPE]: GroupNode,
+      [RF_IMAGE_NODE_TYPE]: EditableNode,
+    }),
     [],
   );
   const edgeTypes = useMemo(() => ({ editableLabel: EditableLabelEdge }), []);
@@ -491,7 +500,7 @@ function GraphEditorInner({
   );
 
   const addNode = useCallback(
-    (position?: { x: number; y: number }) => {
+    (position?: { x: number; y: number }, nodeType?: NodeTypeOption) => {
       const nodeId = crypto.randomUUID() as NodeId;
       const pos = position ?? {
         x: 100 + Math.random() * 200,
@@ -500,6 +509,8 @@ function GraphEditorInner({
       const graphNode: GraphNode = {
         id: nodeId,
         content: '',
+        ...(nodeType === 'group' ? { nodeType: GROUP_NODE_TYPE } : {}),
+        ...(nodeType === 'image' ? { nodeType: IMAGE_NODE_TYPE } : {}),
       };
       const layout: NodeLayout = {
         nodeId,
@@ -579,7 +590,8 @@ function GraphEditorInner({
   useClipboard(getNodes, getEdges, dispatch);
   const { contextMenu, onEdgeContextMenu, setEdgePathType } =
     useEdgeContextMenu(getEdges, dispatch);
-  const { onPaneClick } = usePaneDoubleClick(screenToFlowPosition, addNode);
+  const { onPaneClick, nodeTypeMenu, clearNodeTypeMenu } =
+    usePaneDoubleClick(screenToFlowPosition);
 
   // --- PNG export ---
   const handleExportPng = useCallback(() => {
@@ -715,6 +727,15 @@ function GraphEditorInner({
             </button>
           </Panel>
         </ReactFlow>
+        {nodeTypeMenu && (
+          <NodeTypeMenu
+            position={nodeTypeMenu.screenPos}
+            onSelect={(nodeType) => {
+              addNode(nodeTypeMenu.flowPos, nodeType);
+              clearNodeTypeMenu();
+            }}
+          />
+        )}
         {contextMenu && (
           <EdgeContextMenu
             contextMenu={contextMenu}

--- a/src/client/src/NodeTypeMenu.tsx
+++ b/src/client/src/NodeTypeMenu.tsx
@@ -9,8 +9,8 @@ type Props = {
 
 export function NodeTypeMenu({ position, onSelect }: Props) {
   return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: menu uses mousedown to block propagation
     <div
+      data-node-type-menu
       style={{
         position: 'fixed',
         top: position.y,
@@ -23,7 +23,6 @@ export function NodeTypeMenu({ position, onSelect }: Props) {
         minWidth: 160,
         padding: '4px 0',
       }}
-      onMouseDown={(e) => e.stopPropagation()}
     >
       <div
         style={{

--- a/src/client/src/NodeTypeMenu.tsx
+++ b/src/client/src/NodeTypeMenu.tsx
@@ -1,0 +1,68 @@
+import { DIALOG_Z_INDEX } from './ConfirmDialog';
+
+export type NodeTypeOption = 'markdown' | 'group' | 'image';
+
+type Props = {
+  position: { x: number; y: number };
+  onSelect: (nodeType: NodeTypeOption) => void;
+};
+
+export function NodeTypeMenu({ position, onSelect }: Props) {
+  return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: menu uses mousedown to block propagation
+    <div
+      style={{
+        position: 'fixed',
+        top: position.y,
+        left: position.x,
+        background: '#fff',
+        border: '1px solid #ddd',
+        borderRadius: 6,
+        boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
+        zIndex: DIALOG_Z_INDEX,
+        minWidth: 160,
+        padding: '4px 0',
+      }}
+      onMouseDown={(e) => e.stopPropagation()}
+    >
+      <div
+        style={{
+          padding: '4px 14px 6px',
+          fontSize: 11,
+          color: '#888',
+          borderBottom: '1px solid #eee',
+          marginBottom: 4,
+        }}
+      >
+        ノードの種類
+      </div>
+      {(
+        [
+          ['markdown', 'Markdown'] as const,
+          ['group', 'グループ'] as const,
+          ['image', '画像'] as const,
+        ] as [NodeTypeOption, string][]
+      ).map(([type, label]) => (
+        <button
+          key={type}
+          type="button"
+          onClick={() => onSelect(type)}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+            width: '100%',
+            padding: '6px 14px',
+            textAlign: 'left',
+            background: 'none',
+            border: 'none',
+            fontSize: 13,
+            cursor: 'pointer',
+          }}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/client/src/graphTransform.test.md
+++ b/src/client/src/graphTransform.test.md
@@ -32,5 +32,8 @@
 | label なし Edge | label が undefined になる |
 | label が string でない | undefined にフォールバックする |
 | label が undefined のノード | content が空文字になる |
+| nodeType=group のノード | groupNode 型に変換される |
+| nodeType=image のノード | imageNode 型に変換される |
 | toFlowNodes → fromFlowNodes の往復 | 対称性 (データロスなし) |
 | toFlowEdges → fromFlowEdges の往復 | 対称性 (label 保持) |
+| imageNode 型の逆変換 | fromFlowNodes で nodeType=image が復元される |

--- a/src/client/src/graphTransform.test.ts
+++ b/src/client/src/graphTransform.test.ts
@@ -287,6 +287,13 @@ describe('toFlowNodes: グループノード (parentId / nodeType)', () => {
     expect(toFlowNodes(nodes, layouts)[0].type).toBe('groupNode');
   });
 
+  it('nodeType=image の GraphNode は imageNode 型に変換される', () => {
+    const nodes: GraphNode[] = [
+      { id: 'i1' as NodeId, content: '', nodeType: 'image' },
+    ];
+    expect(toFlowNodes(nodes)[0].type).toBe('imageNode');
+  });
+
   it('parentId を持つ GraphNode は parentId が引き継がれる', () => {
     const nodes: GraphNode[] = [
       { id: 'n1' as NodeId, content: 'child', parentId: 'g1' as NodeId },
@@ -322,6 +329,19 @@ describe('fromFlowNodes: parentId / groupNode', () => {
       },
     ];
     expect(fromFlowNodes(flowNodes).nodes[0].nodeType).toBe('group');
+    expect(fromFlowNodes(flowNodes).layouts[0]).not.toHaveProperty('nodeType');
+  });
+
+  it('imageNode 型は GraphNode.nodeType=image として保存される', () => {
+    const flowNodes: Node[] = [
+      {
+        id: 'i1',
+        position: { x: 0, y: 0 },
+        data: { label: '画像' },
+        type: 'imageNode',
+      },
+    ];
+    expect(fromFlowNodes(flowNodes).nodes[0].nodeType).toBe('image');
     expect(fromFlowNodes(flowNodes).layouts[0]).not.toHaveProperty('nodeType');
   });
 });

--- a/src/client/src/graphTransform.ts
+++ b/src/client/src/graphTransform.ts
@@ -13,7 +13,9 @@ export const DEFAULT_NODE_STYLE = { width: 160, height: 80 };
 export const GROUP_PADDING = 20;
 export const GROUP_TITLE_HEIGHT = 30;
 export const GROUP_NODE_TYPE = 'group' as const; // GraphNode.nodeType (データモデル)
+export const IMAGE_NODE_TYPE = 'image' as const;
 export const RF_GROUP_NODE_TYPE = 'groupNode' as const; // React Flow の node.type
+export const RF_IMAGE_NODE_TYPE = 'imageNode' as const;
 export const PNG_EXPORT_WIDTH = 1920;
 export const PNG_EXPORT_HEIGHT = 1080;
 export const PNG_EXPORT_MIN_ZOOM = 0.5;
@@ -44,7 +46,11 @@ export function toFlowNodes(
         conflicted: conflictedNodeIds?.has(n.id) ?? false,
       },
       type:
-        n.nodeType === GROUP_NODE_TYPE ? RF_GROUP_NODE_TYPE : 'editableNode',
+        n.nodeType === GROUP_NODE_TYPE
+          ? RF_GROUP_NODE_TYPE
+          : n.nodeType === IMAGE_NODE_TYPE
+            ? RF_IMAGE_NODE_TYPE
+            : 'editableNode',
       parentId: n.parentId,
       style:
         layout.width !== undefined || layout.height !== undefined
@@ -121,6 +127,7 @@ export function fromFlowNodes(nodes: Node[]): {
     id: n.id as NodeId,
     content: String(n.data.label ?? ''),
     ...(n.type === RF_GROUP_NODE_TYPE ? { nodeType: GROUP_NODE_TYPE } : {}),
+    ...(n.type === RF_IMAGE_NODE_TYPE ? { nodeType: IMAGE_NODE_TYPE } : {}),
     ...(n.parentId ? { parentId: n.parentId as NodeId } : {}),
   }));
 

--- a/src/client/src/hooks/usePaneDoubleClick.ts
+++ b/src/client/src/hooks/usePaneDoubleClick.ts
@@ -55,16 +55,21 @@ export function usePaneDoubleClick(
   const clearNodeTypeMenu = useCallback(() => setNodeTypeMenu(null), []);
 
   // メニュー外クリック / ESC で閉じる
+  // ReactFlow が pane 上のイベント伝播を止めるため capture フェーズで捕捉する
   useEffect(() => {
     if (!nodeTypeMenu) return;
-    const onMouseDown = () => setNodeTypeMenu(null);
+    const onMouseDown = (e: Event) => {
+      const target = e.target as HTMLElement | null;
+      if (target?.closest('[data-node-type-menu]')) return;
+      setNodeTypeMenu(null);
+    };
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') setNodeTypeMenu(null);
     };
-    window.addEventListener('mousedown', onMouseDown);
+    window.addEventListener('mousedown', onMouseDown, true);
     window.addEventListener('keydown', onKeyDown);
     return () => {
-      window.removeEventListener('mousedown', onMouseDown);
+      window.removeEventListener('mousedown', onMouseDown, true);
       window.removeEventListener('keydown', onKeyDown);
     };
   }, [nodeTypeMenu]);

--- a/src/client/src/hooks/usePaneDoubleClick.ts
+++ b/src/client/src/hooks/usePaneDoubleClick.ts
@@ -1,18 +1,27 @@
 import type { MouseEvent } from 'react';
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 const DOUBLE_CLICK_INTERVAL_MS = 300;
 const DOUBLE_CLICK_THRESHOLD_PX = 5;
+
+export type NodeTypeMenuState = {
+  screenPos: { x: number; y: number };
+  flowPos: { x: number; y: number };
+} | null;
 
 export function usePaneDoubleClick(
   screenToFlowPosition: (pos: { x: number; y: number }) => {
     x: number;
     y: number;
   },
-  addNode: (position?: { x: number; y: number }) => void,
-): { onPaneClick: (e: MouseEvent) => void } {
+): {
+  onPaneClick: (e: MouseEvent) => void;
+  nodeTypeMenu: NodeTypeMenuState;
+  clearNodeTypeMenu: () => void;
+} {
   const lastPaneClickTime = useRef(0);
   const lastPaneClickPos = useRef({ x: 0, y: 0 });
+  const [nodeTypeMenu, setNodeTypeMenu] = useState<NodeTypeMenuState>(null);
 
   const onPaneClick = useCallback(
     (e: MouseEvent) => {
@@ -26,16 +35,39 @@ export function usePaneDoubleClick(
         now - lastPaneClickTime.current < DOUBLE_CLICK_INTERVAL_MS &&
         isSameSpot
       ) {
-        const pos = screenToFlowPosition({ x: e.clientX, y: e.clientY });
-        addNode(pos);
+        const flowPos = screenToFlowPosition({
+          x: e.clientX,
+          y: e.clientY,
+        });
+        setNodeTypeMenu({
+          screenPos: { x: e.clientX, y: e.clientY },
+          flowPos,
+        });
         lastPaneClickTime.current = 0;
       } else {
         lastPaneClickTime.current = now;
         lastPaneClickPos.current = { x: e.clientX, y: e.clientY };
       }
     },
-    [screenToFlowPosition, addNode],
+    [screenToFlowPosition],
   );
 
-  return { onPaneClick };
+  const clearNodeTypeMenu = useCallback(() => setNodeTypeMenu(null), []);
+
+  // メニュー外クリック / ESC で閉じる
+  useEffect(() => {
+    if (!nodeTypeMenu) return;
+    const onMouseDown = () => setNodeTypeMenu(null);
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setNodeTypeMenu(null);
+    };
+    window.addEventListener('mousedown', onMouseDown);
+    window.addEventListener('keydown', onKeyDown);
+    return () => {
+      window.removeEventListener('mousedown', onMouseDown);
+      window.removeEventListener('keydown', onKeyDown);
+    };
+  }, [nodeTypeMenu]);
+
+  return { onPaneClick, nodeTypeMenu, clearNodeTypeMenu };
 }

--- a/src/shared/src/schemas.ts
+++ b/src/shared/src/schemas.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 export const GROUP_NODE_TYPE = 'group' as const;
+export const IMAGE_NODE_TYPE = 'image' as const;
 
 // --- Branded ID schemas (UUID enforced at API boundaries) ---
 export const NodeIdSchema = z.string().uuid().brand<'NodeId'>();
@@ -47,7 +48,7 @@ export const GraphNodeSchema = z.object({
   id: NodeIdSchema,
   content: z.string(),
   properties: z.record(z.string(), z.unknown()).optional(),
-  nodeType: z.literal(GROUP_NODE_TYPE).optional(),
+  nodeType: z.enum([GROUP_NODE_TYPE, IMAGE_NODE_TYPE]).optional(),
   parentId: NodeIdSchema.optional(),
 });
 
@@ -126,7 +127,7 @@ export const CommitOperationSchema = z.discriminatedUnion('op', [
     nodeId: z.string().uuid(),
     content: z.string(),
     properties: z.record(z.string(), z.unknown()).optional(),
-    nodeType: z.literal(GROUP_NODE_TYPE).optional(),
+    nodeType: z.enum([GROUP_NODE_TYPE, IMAGE_NODE_TYPE]).optional(),
     parentId: z.string().uuid().optional(),
   }),
   z.object({


### PR DESCRIPTION
## Summary

- ペインのダブルクリック時に markdown / グループ / 画像 からノード種類を選べるポップアップメニューを表示
- `nodeType: 'image'` をデータモデルに追加（ANA-85 の準備）
- 画像ノードは当面 `EditableNode` として表示（ANA-85 で `ImageNode` に切り替え）
- メニュー外クリックまたは Esc でメニューが閉じる

## Test plan

- [x] `bun run typecheck` エラーなし
- [x] `bun test` 290 pass / 0 fail
- [ ] 手動確認: ペインのダブルクリック → メニュー表示 → Markdown/グループ/画像 の選択 → ノード作成
- [ ] 手動確認: メニュー外クリック / Esc でメニューが閉じる
- [x] 手動確認: 画像ノードを保存→再読み込みで `nodeType: 'image'` が保持される

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)