### PR TITLE
左サイドバーで File の三角アイコンをクリックしても展開されないバグの修正

### DIFF
--- a/src/client/src/Sidebar.tsx
+++ b/src/client/src/Sidebar.tsx
@@ -233,7 +233,10 @@ export function Sidebar({
                 {/* 展開トグル */}
                 <button
                   type="button"
-                  onClick={() => onToggleExpand(f.id)}
+                  onClick={() => {
+                    if (!isActiveFile) onOpenFile(f.id);
+                    onToggleExpand(f.id);
+                  }}
                   style={{
                     background: 'none',
                     border: 'none',
@@ -264,7 +267,10 @@ export function Sidebar({
                     textAlign: 'left',
                     padding: 0,
                   }}
-                  onClick={() => onToggleExpand(f.id)}
+                  onClick={() => {
+                    if (!isActiveFile) onOpenFile(f.id);
+                    onToggleExpand(f.id);
+                  }}
                 >
                   {f.name}
                 </button>


### PR DESCRIPTION
## Summary

左サイドバーで File の三角アイコン（▶/▼）をクリックしても内容（シート一覧）が展開されないバグを修正。

## 原因

`Sidebar.tsx` の展開トグルは `onToggleExpand(f.id)` のみを呼び出しており、`onOpenFile` を呼んでいなかった。展開表示には `fileData`（= `activeFile`）が必要だが、ファイルがアクティブでないと `fileData` が `null` になり、シート一覧が表示されなかった。

## 修正

展開トグル（▶/▼）およびファイル名ボタンのクリック時に、非アクティブなファイルであれば先に `onOpenFile(f.id)` を呼ぶようにした。

```tsx
onClick={() => {
  if (!isActiveFile) onOpenFile(f.id);
  onToggleExpand(f.id);
}}
```

## Test plan

- [x] `bun run typecheck` エラーなし
- [x] `bun test` 293 pass / 0 fail
- [x] `bun run lint` エラーなし
- [x] 手動: 三角アイコンクリックでシート一覧が展開される
- [x] 手動: 別ファイル操作後やリロード後も展開が動作する

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)