### PR TITLE
trunk切替時にブランチ編集内容を自動保存する

### DIFF
--- a/src/client/src/hooks/useBranchOperations.ts
+++ b/src/client/src/hooks/useBranchOperations.ts
@@ -21,6 +21,7 @@ import {
   fetchCommitsForBranch,
   mergeBranchToTrunk,
   sheets,
+  syncBranchSheetToAtproto,
   syncFileToAtproto,
   TRUNK_PREFIX,
   updateBranchStatus,
@@ -199,6 +200,23 @@ export function useBranchOperations({
       latestCommitRef.current = null;
 
       if (!branch || branch.name === TRUNK_PREFIX) {
+        // ブランチから trunk に戻る前に、現在の編集内容を branch に保存
+        if (
+          activeBranch &&
+          activeBranch.name !== TRUNK_PREFIX &&
+          activeSheetId &&
+          activeFile
+        ) {
+          const sheet = activeFile.sheets.find((s) => s.id === activeSheetId);
+          if (sheet) {
+            try {
+              const sheetRef = await sheets.ref(activeSheetId);
+              await syncBranchSheetToAtproto(sheet, sheetRef, activeBranch.id);
+            } catch (err) {
+              console.warn('[branch] pre-switch save failed:', err);
+            }
+          }
+        }
         setActiveBranch(branch);
         setLastCommitBase(null);
         setBranchOriginalBase(null);
@@ -266,7 +284,7 @@ export function useBranchOperations({
         console.warn('[branch] select failed:', err);
       }
     },
-    [activeFile, onSetActiveFile, deps, activeBranch],
+    [activeFile, activeSheetId, onSetActiveFile, deps, activeBranch],
   );
 
   const handleCreateBranch = useCallback(


### PR DESCRIPTION
## Summary

ブランチで編集後、commit せずに trunk に切り替えると編集内容が失われるバグを修正。

## 原因

`handleSelectBranch` で trunk に戻る際、ブランチの編集内容を PDS に保存せずに `preBranchFile` で trunk の状態を復元していた。auto-save タイマー (1000ms) が完了する前に切り替えると、編集が PDS に同期されないままブランチ状態がクリアされていた。

## 修正

trunk に戻る直前に、現在のブランチ編集内容を `syncBranchSheetToAtproto` で PDS に保存する。保存に失敗した場合もエラーログを出すだけで処理は継続する。

```ts
if (!branch || branch.name === TRUNK_PREFIX) {
  // ブランチから trunk に戻る前に編集内容を保存
  if (activeBranch && activeBranch.name !== TRUNK_PREFIX && activeSheetId && activeFile) {
    const sheet = activeFile.sheets.find((s) => s.id === activeSheetId);
    if (sheet) {
      await syncBranchSheetToAtproto(sheet, sheetRef, activeBranch.id);
    }
  }
  // ... 既存のリセット処理
}
```

## Test plan

- [x] `bun run typecheck` エラーなし
- [x] `bun test` 303 pass / 0 fail
- [ ] 手動: ブランチで編集 → commit せずに trunk に切替 → 再度ブランチに戻る → 編集が残っている

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)