### PR TITLE
node/edge の追加(緑)と更新(オレンジ)の差分表示を分離

### DIFF
--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -169,8 +169,10 @@ export default function App() {
             file={fileOps.activeFile}
             activeSheetId={fileOps.activeSheetId}
             onChange={handleChange}
-            conflictedNodeIds={branchOps.conflictedNodeIds}
-            conflictedEdgeIds={branchOps.conflictedEdgeIds}
+            addedNodeIds={branchOps.addedNodeIds}
+            updatedNodeIds={branchOps.updatedNodeIds}
+            addedEdgeIds={branchOps.addedEdgeIds}
+            updatedEdgeIds={branchOps.updatedEdgeIds}
             deletedNodes={branchOps.deletedNodes}
             deletedEdges={branchOps.deletedEdges}
             deletedNodeLayouts={branchOps.deletedNodeLayouts}

--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -247,7 +247,7 @@ export default function App() {
               disabled={
                 branchOps.pendingOps.length > 0 ||
                 branchOps.newCommitsSinceMerge === 0 ||
-                branch.status !== BRANCH_STATUS.OPEN
+                branch.status === BRANCH_STATUS.CLOSED
               }
               style={{
                 padding: '6px 16px',
@@ -255,7 +255,7 @@ export default function App() {
                 background:
                   branchOps.pendingOps.length === 0 &&
                   branchOps.newCommitsSinceMerge > 0 &&
-                  branch.status === BRANCH_STATUS.OPEN
+                  branch.status !== BRANCH_STATUS.CLOSED
                     ? '#f97316'
                     : '#ccc',
                 color: '#fff',
@@ -264,7 +264,7 @@ export default function App() {
                 cursor:
                   branchOps.pendingOps.length === 0 &&
                   branchOps.newCommitsSinceMerge > 0 &&
-                  branch.status === BRANCH_STATUS.OPEN
+                  branch.status !== BRANCH_STATUS.CLOSED
                     ? 'pointer'
                     : 'not-allowed',
               }}

--- a/src/client/src/EditableNode.tsx
+++ b/src/client/src/EditableNode.tsx
@@ -50,7 +50,7 @@ export function EditableNode({ id, data, selected }: NodeProps) {
   );
 
   const label = String(data.label ?? '');
-  const conflicted = data.conflicted === true;
+  const diffType = data.diffType as 'add' | 'update' | undefined;
   const ghost = data.ghost === true;
 
   const { editing, inputValue, setInputValue, startEdit, confirm, cancel } =
@@ -121,8 +121,16 @@ export function EditableNode({ id, data, selected }: NodeProps) {
         style={{
           padding: '8px 12px',
           borderRadius: 6,
-          border: conflicted ? '2px solid #f97316' : '1px solid #ccc',
-          background: conflicted ? '#fff7ed' : '#fff',
+          border: diffType
+            ? diffType === 'add'
+              ? '2px solid #16a34a'
+              : '2px solid #f97316'
+            : '1px solid #ccc',
+          background: diffType
+            ? diffType === 'add'
+              ? '#f0fdf4'
+              : '#fff7ed'
+            : '#fff',
           width: '100%',
           height: '100%',
           boxSizing: 'border-box',

--- a/src/client/src/GraphEditor.tsx
+++ b/src/client/src/GraphEditor.tsx
@@ -122,8 +122,10 @@ type Props = {
   file: GraphFile;
   activeSheetId: SheetId;
   onChange: (file: GraphFile) => void;
-  conflictedNodeIds?: Set<string>;
-  conflictedEdgeIds?: Set<string>;
+  addedNodeIds?: Set<string>;
+  updatedNodeIds?: Set<string>;
+  addedEdgeIds?: Set<string>;
+  updatedEdgeIds?: Set<string>;
   deletedNodes?: GraphNode[];
   deletedEdges?: GraphEdge[];
   deletedNodeLayouts?: NodeLayout[];
@@ -136,8 +138,10 @@ function GraphEditorInner({
   file,
   activeSheetId,
   onChange,
-  conflictedNodeIds,
-  conflictedEdgeIds,
+  addedNodeIds,
+  updatedNodeIds,
+  addedEdgeIds,
+  updatedEdgeIds,
   deletedNodes,
   deletedEdges,
   deletedNodeLayouts,
@@ -159,7 +163,8 @@ function GraphEditorInner({
       activeSheet?.layouts ?? [],
       deletedNodes ?? [],
       deletedNodeLayouts ?? [],
-      conflictedNodeIds,
+      addedNodeIds,
+      updatedNodeIds,
     ),
   );
   const [edges, setEdges, onEdgesChange] = useEdgesState(
@@ -169,7 +174,8 @@ function GraphEditorInner({
       deletedEdges ?? [],
       deletedEdgeLayouts ?? [],
       ghostDeletedNodeIds,
-      conflictedEdgeIds,
+      addedEdgeIds,
+      updatedEdgeIds,
     ),
   );
 
@@ -209,7 +215,8 @@ function GraphEditorInner({
         sheet?.layouts ?? [],
         deletedNodesRef.current ?? [],
         deletedNodeLayoutsRef.current ?? [],
-        conflictedNodeIds,
+        addedNodeIds,
+        updatedNodeIds,
       ),
     );
     setEdges(
@@ -219,7 +226,8 @@ function GraphEditorInner({
         deletedEdgesRef.current ?? [],
         deletedEdgeLayoutsRef.current ?? [],
         new Set((deletedNodesRef.current ?? []).map((n) => n.id)),
-        conflictedEdgeIds,
+        addedEdgeIds,
+        updatedEdgeIds,
       ),
     );
     // ReactFlow の初期 dimensions 計測が完了するまで onChange を抑制 (150ms)
@@ -235,26 +243,44 @@ function GraphEditorInner({
   useEffect(() => {
     conflictUpdatePendingRef.current = true;
     setNodes((current) =>
-      current.map((n) => ({
-        ...n,
-        data: { ...n.data, conflicted: conflictedNodeIds?.has(n.id) ?? false },
-      })),
+      current.map((n) => {
+        const dt: 'add' | 'update' | undefined = addedNodeIds?.has(n.id)
+          ? 'add'
+          : updatedNodeIds?.has(n.id)
+            ? 'update'
+            : undefined;
+        return {
+          ...n,
+          data: { ...n.data, diffType: dt },
+        };
+      }),
     );
-  }, [conflictedNodeIds, setNodes]);
+  }, [addedNodeIds, updatedNodeIds, setNodes]);
 
   useEffect(() => {
     conflictUpdatePendingRef.current = true;
     setEdges((current) =>
       current.map((e) => {
-        const conflicted = conflictedEdgeIds?.has(e.id) ?? false;
+        const added = addedEdgeIds?.has(e.id) ?? false;
+        const updated = updatedEdgeIds?.has(e.id) ?? false;
+        const dt: 'add' | 'update' | undefined = added
+          ? 'add'
+          : updated
+            ? 'update'
+            : undefined;
         return {
           ...e,
-          style: conflicted ? { stroke: '#f97316', strokeWidth: 3 } : undefined,
-          data: { ...e.data, conflicted },
+          style: dt
+            ? {
+                stroke: dt === 'add' ? '#16a34a' : '#f97316',
+                strokeWidth: 3,
+              }
+            : undefined,
+          data: { ...e.data, diffType: dt },
         };
       }),
     );
-  }, [conflictedEdgeIds, setEdges]);
+  }, [addedEdgeIds, updatedEdgeIds, setEdges]);
 
   // 削除ノード/エッジが変わったらゴーストを同期
   useEffect(() => {

--- a/src/client/src/GroupNode.tsx
+++ b/src/client/src/GroupNode.tsx
@@ -89,6 +89,7 @@ export function GroupNode({
     [id, screenToFlowPosition, dispatch],
   );
   const label = String(data.label ?? '');
+  const diffType = data.diffType as 'add' | 'update' | undefined;
   const ghost = data.ghost === true;
 
   const {
@@ -164,8 +165,16 @@ export function GroupNode({
           width: '100%',
           height: '100%',
           borderRadius: 8,
-          border: '2px solid #7c9ef8',
-          background: 'rgba(79, 110, 247, 0.06)',
+          border: diffType
+            ? diffType === 'add'
+              ? '2px solid #16a34a'
+              : '2px solid #f97316'
+            : '2px solid #7c9ef8',
+          background: diffType
+            ? diffType === 'add'
+              ? 'rgba(22, 163, 74, 0.06)'
+              : 'rgba(249, 115, 22, 0.06)'
+            : 'rgba(79, 110, 247, 0.06)',
           boxSizing: 'border-box',
           display: 'flex',
           flexDirection: 'column',

--- a/src/client/src/ImageNode.tsx
+++ b/src/client/src/ImageNode.tsx
@@ -15,8 +15,9 @@ import { useInlineEdit } from './hooks/useInlineEdit';
 
 type ImageNodeData = {
   label: string;
-  conflicted: boolean;
+  diffType?: 'add' | 'update';
   properties?: Record<string, unknown>;
+  ghost?: boolean;
 };
 
 export function ImageNode({ id, data, selected }: NodeProps) {
@@ -30,7 +31,7 @@ export function ImageNode({ id, data, selected }: NodeProps) {
     (nodeData.properties?.imageBlobMimeType as string) ?? '';
   const imageDataUrl = (nodeData.properties?.imageDataUrl as string) ?? '';
   const label = String(nodeData.label ?? '');
-  const conflicted = nodeData.conflicted === true;
+  const diffType = nodeData.diffType as 'add' | 'update' | undefined;
   const ghost = nodeData.ghost === true;
 
   const preSizeRef = useRef({ width: 0, height: 0 });
@@ -246,8 +247,16 @@ export function ImageNode({ id, data, selected }: NodeProps) {
           width: '100%',
           height: '100%',
           borderRadius: 6,
-          border: conflicted ? '2px solid #f97316' : '1px solid #ccc',
-          background: conflicted ? '#fff7ed' : '#fff',
+          border: diffType
+            ? diffType === 'add'
+              ? '2px solid #16a34a'
+              : '2px solid #f97316'
+            : '1px solid #ccc',
+          background: diffType
+            ? diffType === 'add'
+              ? '#f0fdf4'
+              : '#fff7ed'
+            : '#fff',
           boxSizing: 'border-box',
           display: 'flex',
           flexDirection: 'column',

--- a/src/client/src/graphTransform.ts
+++ b/src/client/src/graphTransform.ts
@@ -26,7 +26,8 @@ export const DEFAULT_EDGE_PATH_TYPE = 'bezier' as const;
 export function toFlowNodes(
   nodes: GraphNode[],
   layouts: NodeLayout[] = [],
-  conflictedNodeIds?: Set<string>,
+  addedNodeIds?: Set<string>,
+  updatedNodeIds?: Set<string>,
 ): Node[] {
   const layoutMap = new Map(layouts.map((l) => [l.nodeId as string, l]));
   const result = nodes.map((n) => {
@@ -35,6 +36,11 @@ export function toFlowNodes(
       x: 0,
       y: 0,
     };
+    const diffType: 'add' | 'update' | undefined = addedNodeIds?.has(n.id)
+      ? 'add'
+      : updatedNodeIds?.has(n.id)
+        ? 'update'
+        : undefined;
     return {
       id: n.id,
       position: {
@@ -43,7 +49,7 @@ export function toFlowNodes(
       },
       data: {
         label: n.content,
-        conflicted: conflictedNodeIds?.has(n.id) ?? false,
+        diffType,
         ...(n.properties ? { properties: n.properties } : {}),
       },
       type:
@@ -93,12 +99,19 @@ export function toFlowNodes(
 export function toFlowEdges(
   edges: GraphEdge[],
   edgeLayouts: EdgeLayout[] = [],
-  conflictedEdgeIds?: Set<string>,
+  addedEdgeIds?: Set<string>,
+  updatedEdgeIds?: Set<string>,
 ): Edge[] {
   const layoutMap = new Map(edgeLayouts.map((l) => [l.edgeId as string, l]));
   return edges.map((e) => {
     const layout = layoutMap.get(e.id);
-    const conflicted = conflictedEdgeIds?.has(e.id) ?? false;
+    const added = addedEdgeIds?.has(e.id) ?? false;
+    const updated = updatedEdgeIds?.has(e.id) ?? false;
+    const diffType: 'add' | 'update' | undefined = added
+      ? 'add'
+      : updated
+        ? 'update'
+        : undefined;
     return {
       id: e.id,
       source: e.source,
@@ -108,12 +121,17 @@ export function toFlowEdges(
       label: e.label,
       type: 'editableLabel',
       markerEnd: { type: MarkerType.ArrowClosed },
-      style: conflicted ? { stroke: '#f97316', strokeWidth: 3 } : undefined,
+      style: diffType
+        ? {
+            stroke: diffType === 'add' ? '#16a34a' : '#f97316',
+            strokeWidth: 3,
+          }
+        : undefined,
       data: {
         pathType: layout?.pathType ?? DEFAULT_EDGE_PATH_TYPE,
         labelOffsetX: layout?.labelOffsetX ?? 0,
         labelOffsetY: layout?.labelOffsetY ?? 0,
-        conflicted,
+        diffType,
       },
     };
   });
@@ -375,9 +393,10 @@ export function toFlowAndGhostNodes(
   layouts: NodeLayout[],
   deletedNodes: GraphNode[],
   deletedLayouts: NodeLayout[],
-  conflictedNodeIds?: Set<string>,
+  addedNodeIds?: Set<string>,
+  updatedNodeIds?: Set<string>,
 ): Node[] {
-  const active = toFlowNodes(nodes, layouts, conflictedNodeIds);
+  const active = toFlowNodes(nodes, layouts, addedNodeIds, updatedNodeIds);
   const ghosts = toFlowNodes(deletedNodes, deletedLayouts).map((n) => ({
     ...n,
     id: `ghost-${n.id}`,
@@ -395,9 +414,10 @@ export function toFlowAndGhostEdges(
   deletedEdges: GraphEdge[],
   deletedLayouts: EdgeLayout[],
   deletedNodeIds: Set<string>,
-  conflictedEdgeIds?: Set<string>,
+  addedEdgeIds?: Set<string>,
+  updatedEdgeIds?: Set<string>,
 ): Edge[] {
-  const active = toFlowEdges(edges, edgeLayouts, conflictedEdgeIds);
+  const active = toFlowEdges(edges, edgeLayouts, addedEdgeIds, updatedEdgeIds);
   const ghosts = toFlowEdges(deletedEdges, deletedLayouts).map((e) => ({
     ...e,
     id: `ghost-${e.id}`,

--- a/src/client/src/hooks/useBranchOperations.test.ts
+++ b/src/client/src/hooks/useBranchOperations.test.ts
@@ -83,8 +83,8 @@ describe('useBranchOperations', () => {
 
     it('diff 関連の Set が空', async () => {
       const { result } = await render();
-      expect(result.current.branchDiffNodeIds.size).toBe(0);
-      expect(result.current.branchDiffEdgeIds.size).toBe(0);
+      expect(result.current.addedNodeIds.size).toBe(0);
+      expect(result.current.addedEdgeIds.size).toBe(0);
     });
 
     it('sheetBranches の active sheet に対応する branches は空', async () => {
@@ -375,7 +375,7 @@ describe('useBranchOperations', () => {
   });
 
   describe('deletedNodes / deletedEdges (ゴースト表示用)', () => {
-    it('node.remove op → deletedNodes に含まれ、branchDiffNodeIds に含まれない', async () => {
+    it('node.remove op → deletedNodes に含まれ、addedNodeIds に含まれない', async () => {
       const { result, deps } = await render();
       deps._setComputeOps([{ op: 'node.remove', nodeId: 'n1' }]);
 
@@ -391,10 +391,10 @@ describe('useBranchOperations', () => {
       });
 
       expect(result.current.deletedNodes).toEqual([]); // base に n1 が存在しない
-      expect(result.current.branchDiffNodeIds.size).toBe(0); // remove は conflicted に入らない
+      expect(result.current.addedNodeIds.size).toBe(0); // remove は conflicted に入らない
     });
 
-    it('edge.remove op → branchDiffEdgeIds に含まれない', async () => {
+    it('edge.remove op → addedEdgeIds に含まれない', async () => {
       const { result, deps } = await render();
       deps._setComputeOps([{ op: 'edge.remove', edgeId: 'e1' }]);
 
@@ -409,10 +409,10 @@ describe('useBranchOperations', () => {
         });
       });
 
-      expect(result.current.branchDiffEdgeIds.has('e1')).toBe(false);
+      expect(result.current.addedEdgeIds.has('e1')).toBe(false);
     });
 
-    it('node.add op → branchDiffNodeIds に含まれる', async () => {
+    it('node.add op → addedNodeIds に含まれる', async () => {
       const { result, deps } = await render();
       deps._setComputeOps([{ op: 'node.add', nodeId: 'n1', content: 'hi' }]);
 
@@ -427,7 +427,7 @@ describe('useBranchOperations', () => {
         });
       });
 
-      expect(result.current.branchDiffNodeIds.has('n1')).toBe(true);
+      expect(result.current.addedNodeIds.has('n1')).toBe(true);
     });
   });
 

--- a/src/client/src/hooks/useBranchOperations.ts
+++ b/src/client/src/hooks/useBranchOperations.ts
@@ -126,21 +126,30 @@ export function useBranchOperations({
     latestCommitRef.current = null;
   }, [activeFile?.id]);
 
-  const [branchDiffNodeIds, branchDiffEdgeIds] = useMemo(() => {
-    if (isTrunk || !branchOriginalBase || !activeSheet) {
-      return [new Set<string>(), new Set<string>()] as const;
-    }
-    const ops = deps.computeOperations(branchOriginalBase, activeSheet);
-    const nodeIds = new Set<string>();
-    const edgeIds = new Set<string>();
-    for (const op of ops) {
-      // 削除は conflicted に含めない（ゴースト表示用に別途計算）
-      if (op.op === 'node.remove' || op.op === 'edge.remove') continue;
-      if ('nodeId' in op) nodeIds.add(op.nodeId);
-      else if ('edgeId' in op) edgeIds.add(op.edgeId);
-    }
-    return [nodeIds, edgeIds] as const;
-  }, [isTrunk, branchOriginalBase, activeSheet, deps]);
+  const [addedNodeIds, updatedNodeIds, addedEdgeIds, updatedEdgeIds] =
+    useMemo(() => {
+      if (isTrunk || !branchOriginalBase || !activeSheet) {
+        return [
+          new Set<string>(),
+          new Set<string>(),
+          new Set<string>(),
+          new Set<string>(),
+        ] as const;
+      }
+      const ops = deps.computeOperations(branchOriginalBase, activeSheet);
+      const addN = new Set<string>();
+      const updN = new Set<string>();
+      const addE = new Set<string>();
+      const updE = new Set<string>();
+      for (const op of ops) {
+        if (op.op === 'node.add') addN.add(op.nodeId);
+        else if (op.op === 'node.update') updN.add(op.nodeId);
+        else if (op.op === 'edge.add') addE.add(op.edgeId);
+        else if (op.op === 'edge.update') updE.add(op.edgeId);
+        // remove は conflicted に含めない（ゴースト表示用に別途計算）
+      }
+      return [addN, updN, addE, updE] as const;
+    }, [isTrunk, branchOriginalBase, activeSheet, deps]);
 
   // 削除予定のノード/エッジ（base に存在し current に存在しない）
   const [deletedNodes, deletedEdges, deletedNodeLayouts, deletedEdgeLayouts] =
@@ -530,10 +539,12 @@ export function useBranchOperations({
     commitDialogOpen,
     setCommitDialogOpen,
     isTrunk,
-    branchDiffNodeIds,
-    branchDiffEdgeIds,
-    conflictedNodeIds: branchDiffNodeIds,
-    conflictedEdgeIds: branchDiffEdgeIds,
+    addedNodeIds,
+    updatedNodeIds,
+    addedEdgeIds,
+    updatedEdgeIds,
+    conflictedNodeIds: new Set([...addedNodeIds, ...updatedNodeIds]),
+    conflictedEdgeIds: new Set([...addedEdgeIds, ...updatedEdgeIds]),
     deletedNodes: deletedNodes as GraphNode[],
     deletedEdges: deletedEdges as GraphEdge[],
     deletedNodeLayouts: deletedNodeLayouts as NodeLayout[],


### PR DESCRIPTION
## Summary

ブランチの差分表示で、追加されたノード/エッジは緑、更新はオレンジで表示を分離。

## 変更内容

- `useBranchOperations`: `computeOperations` の `op.type` で add/update を分離し、`addedNodeIds`/`updatedNodeIds`/`addedEdgeIds`/`updatedEdgeIds` として返す
- `toFlowNodes`/`toFlowEdges`: `data.conflicted: boolean` → `data.diffType: 'add' | 'update' | undefined` に
- 各ノードコンポーネント: 緑 (`#16a34a`) / オレンジ (`#f97316`) の色分け
- エッジ: 追加=緑線 / 更新=オレンジ線

## 色分け

| 表示 | 色 |
|------|-----|
| 追加 (add) | 緑 `#16a34a` / 背景 `#f0fdf4` |
| 更新 (update) | オレンジ `#f97316` / 背景 `#fff7ed` |
| ゴースト | 灰 `#aaa` |

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)