### PR TITLE
ATProto blob の永続化: NodeRecord に blob 型 image フィールドを追加

### DIFF
--- a/src/client/src/GraphEditor.tsx
+++ b/src/client/src/GraphEditor.tsx
@@ -712,6 +712,7 @@ function GraphEditorInner({
           addNode(pos, 'image', {
             imageBlobCid: blobRef.cid,
             imageBlobMimeType: blobRef.mimeType,
+            imageBlobSize: blobRef.size,
             imageDataUrl: createImageDataUrl(bytes, blobRef.mimeType),
           });
         } catch (err) {
@@ -807,6 +808,7 @@ function GraphEditorInner({
           addNode(pos, 'image', {
             imageBlobCid: blobRef.cid,
             imageBlobMimeType: blobRef.mimeType,
+            imageBlobSize: blobRef.size,
             imageDataUrl: createImageDataUrl(bytes, blobRef.mimeType),
           });
         } catch (err) {

--- a/src/client/src/ImageNode.tsx
+++ b/src/client/src/ImageNode.tsx
@@ -33,6 +33,15 @@ export function ImageNode({ id, data, selected }: NodeProps) {
   const label = String(nodeData.label ?? '');
   const diffType = nodeData.diffType as 'add' | 'update' | undefined;
   const ghost = nodeData.ghost === true;
+  console.log('[ImageNode] props:', {
+    id,
+    imageUrl: !!imageUrl,
+    imageBlobCid: !!imageBlobCid,
+    imageBlobMimeType: !!imageBlobMimeType,
+    imageDataUrlLen: imageDataUrl.length,
+    ghost,
+    diffType,
+  });
 
   const preSizeRef = useRef({ width: 0, height: 0 });
 

--- a/src/client/src/ImageNode.tsx
+++ b/src/client/src/ImageNode.tsx
@@ -33,15 +33,6 @@ export function ImageNode({ id, data, selected }: NodeProps) {
   const label = String(nodeData.label ?? '');
   const diffType = nodeData.diffType as 'add' | 'update' | undefined;
   const ghost = nodeData.ghost === true;
-  console.log('[ImageNode] props:', {
-    id,
-    imageUrl: !!imageUrl,
-    imageBlobCid: !!imageBlobCid,
-    imageBlobMimeType: !!imageBlobMimeType,
-    imageDataUrlLen: imageDataUrl.length,
-    ghost,
-    diffType,
-  });
 
   const preSizeRef = useRef({ width: 0, height: 0 });
 
@@ -378,7 +369,7 @@ export function ImageNode({ id, data, selected }: NodeProps) {
             <span style={{ fontSize: 11, color: '#999' }}>
               画像を読み込み中...
             </span>
-          ) : (
+          ) : displayUrl ? (
             <img
               src={displayUrl}
               alt={label}
@@ -390,7 +381,7 @@ export function ImageNode({ id, data, selected }: NodeProps) {
               }}
               draggable={false}
             />
-          )}
+          ) : null}
         </div>
       </div>
       <Handle type="source" position={Position.Bottom} id="source-bottom" />

--- a/src/client/src/ImageNode.tsx
+++ b/src/client/src/ImageNode.tsx
@@ -94,14 +94,7 @@ export function ImageNode({ id, data, selected }: NodeProps) {
         setBlobUrl(cached);
         return;
       }
-      // 2. data URL (再読込時のメイン表示手段)
-      if (imageDataUrl) {
-        blobUrlFromCache.current = false;
-        blobUrlRef.current = imageDataUrl;
-        setBlobUrl(imageDataUrl);
-        return;
-      }
-      // 3. PDS getBlob (フォールバック)
+      // 3. PDS getBlob
       const did = currentDid();
       resolveBlobUrl(did, imageBlobCid, imageBlobMimeType)
         .then((url) => {
@@ -124,6 +117,11 @@ export function ImageNode({ id, data, selected }: NodeProps) {
             console.error('[ImageNode] blob resolve failed:', err);
         });
     }
+    // 2. data URL (blob CID の有無に関わらず常時フォールバック)
+    if (imageDataUrl && blobUrlRef.current !== imageDataUrl) {
+      blobUrlRef.current = imageDataUrl;
+      setBlobUrl(imageDataUrl);
+    }
     return () => {
       cancelled = true;
     };
@@ -144,7 +142,8 @@ export function ImageNode({ id, data, selected }: NodeProps) {
   // URL 入力
   const [editingUrl, setEditingUrl] = useState(false);
   const [urlInput, setUrlInput] = useState(imageUrl);
-  const showUrlInput = editingUrl || (!imageUrl && !imageBlobCid);
+  const showUrlInput =
+    editingUrl || (!imageUrl && !imageBlobCid && !imageDataUrl);
 
   const commitUrl = useCallback(() => {
     const trimmed = urlInput.trim();

--- a/src/client/src/atproto/blob.ts
+++ b/src/client/src/atproto/blob.ts
@@ -4,6 +4,7 @@ import { currentDid, getAgent } from './client';
 type ImageBlobRef = {
   cid: string;
   mimeType: string;
+  size: number;
 };
 
 export async function uploadImageBlob(
@@ -22,6 +23,7 @@ export async function uploadImageBlob(
   return {
     cid,
     mimeType: blob.mimeType,
+    size: blob.size as number,
   };
 }
 

--- a/src/client/src/atproto/mapper.ts
+++ b/src/client/src/atproto/mapper.ts
@@ -66,10 +66,21 @@ export function nodeToRecord(
   parentRef?: StrongRef,
   createdAt = new Date().toISOString(),
 ): Omit<NodeRecord, '$type'> {
+  const props = node.properties as Record<string, unknown> | undefined;
+  // blob 参照を抽出（PDS が blob を保持するために $type: 'blob' のフィールドが必要）
+  const imageBlob = props?.imageBlobCid
+    ? {
+        $type: 'blob' as const,
+        ref: { $link: props.imageBlobCid as string },
+        mimeType: (props.imageBlobMimeType as string) ?? 'image/png',
+        size: (props.imageBlobSize as number) ?? 0,
+      }
+    : undefined;
   return {
     sheet: sheetRef,
     content: node.content,
     ...(node.properties !== undefined && { properties: node.properties }),
+    ...(imageBlob !== undefined && { image: imageBlob }),
     ...(node.nodeType !== undefined && { nodeType: node.nodeType }),
     ...(parentRef !== undefined && { parent: parentRef }),
     createdAt,
@@ -147,12 +158,17 @@ export function edgeLayoutToRecord(
 // --- ATProto レコード → ドメイン ---
 
 export function recordToNode(rkey: Rkey, record: NodeRecord): GraphNode {
+  const props = (record.properties as Record<string, unknown>) ?? {};
+  // blob 参照から CID/mimeType/size を抽出して properties に設定
+  if (record.image) {
+    props.imageBlobCid = record.image.ref.$link;
+    props.imageBlobMimeType = record.image.mimeType;
+    props.imageBlobSize = record.image.size;
+  }
   return {
     id: NodeIdSchema.parse(idFromRkey(rkey)),
     content: record.content,
-    ...(record.properties !== undefined && {
-      properties: record.properties as Record<string, unknown>,
-    }),
+    ...(Object.keys(props).length > 0 ? { properties: props } : {}),
     ...(record.nodeType !== undefined && { nodeType: record.nodeType }),
     ...(record.parent !== undefined && {
       parentId: NodeIdSchema.parse(idFromRkey(rkeyFromUri(record.parent.uri))),

--- a/src/client/src/atproto/mapper.ts
+++ b/src/client/src/atproto/mapper.ts
@@ -76,6 +76,15 @@ export function nodeToRecord(
         size: (props.imageBlobSize as number) ?? 0,
       }
     : undefined;
+  if (imageBlob) {
+    console.log('[mapper] nodeToRecord image blob:', imageBlob.ref.$link);
+  }
+  if (props?.imageDataUrl) {
+    console.log(
+      '[mapper] nodeToRecord imageDataUrl length:',
+      (props.imageDataUrl as string).length,
+    );
+  }
   return {
     sheet: sheetRef,
     content: node.content,
@@ -161,9 +170,16 @@ export function recordToNode(rkey: Rkey, record: NodeRecord): GraphNode {
   const props = (record.properties as Record<string, unknown>) ?? {};
   // blob 参照から CID/mimeType/size を抽出して properties に設定
   if (record.image) {
+    console.log('[mapper] recordToNode image blob:', record.image.ref.$link);
     props.imageBlobCid = record.image.ref.$link;
     props.imageBlobMimeType = record.image.mimeType;
     props.imageBlobSize = record.image.size;
+  }
+  if (props.imageDataUrl) {
+    console.log(
+      '[mapper] recordToNode imageDataUrl length:',
+      (props.imageDataUrl as string).length,
+    );
   }
   return {
     id: NodeIdSchema.parse(idFromRkey(rkey)),

--- a/src/client/src/atproto/mapper.ts
+++ b/src/client/src/atproto/mapper.ts
@@ -76,15 +76,6 @@ export function nodeToRecord(
         size: (props.imageBlobSize as number) ?? 0,
       }
     : undefined;
-  if (imageBlob) {
-    console.log('[mapper] nodeToRecord image blob:', imageBlob.ref.$link);
-  }
-  if (props?.imageDataUrl) {
-    console.log(
-      '[mapper] nodeToRecord imageDataUrl length:',
-      (props.imageDataUrl as string).length,
-    );
-  }
   return {
     sheet: sheetRef,
     content: node.content,
@@ -170,16 +161,9 @@ export function recordToNode(rkey: Rkey, record: NodeRecord): GraphNode {
   const props = (record.properties as Record<string, unknown>) ?? {};
   // blob 参照から CID/mimeType/size を抽出して properties に設定
   if (record.image) {
-    console.log('[mapper] recordToNode image blob:', record.image.ref.$link);
     props.imageBlobCid = record.image.ref.$link;
     props.imageBlobMimeType = record.image.mimeType;
     props.imageBlobSize = record.image.size;
-  }
-  if (props.imageDataUrl) {
-    console.log(
-      '[mapper] recordToNode imageDataUrl length:',
-      (props.imageDataUrl as string).length,
-    );
   }
   return {
     id: NodeIdSchema.parse(idFromRkey(rkey)),

--- a/src/client/src/atproto/types.ts
+++ b/src/client/src/atproto/types.ts
@@ -31,6 +31,13 @@ export type SheetRecord = {
   createdAt: ISODateString;
 };
 
+export type ImageBlobRef = {
+  $type: 'blob';
+  ref: { $link: string };
+  mimeType: string;
+  size: number;
+};
+
 export type NodeRecord = {
   $type: typeof NSID.node;
   sheet: StrongRef;
@@ -38,6 +45,8 @@ export type NodeRecord = {
   properties?: unknown;
   nodeType?: 'group';
   parent?: StrongRef;
+  /** blob 型フィールド。PDS が blob を保持するために必要 */
+  image?: ImageBlobRef;
   createdAt: ISODateString;
 };
 


### PR DESCRIPTION
## Summary

画像の永続化を改善。PDS の制約により blob 型フィールドは機能しなかったが、data URL による確実な永続化を実現。

## 変更内容

- `NodeRecord`: `image` blob 型フィールドを追加（この PDS では保持されないが、将来有効になる可能性）
- `nodeToRecord`: properties から blob 参照を構築して `image` フィールドに設定
- `recordToNode`: blob 参照から CID/mimeType を抽出
- `uploadImageBlob`: 戻り値に `size` を追加
- `ImageNode`: `imageBlobCid` が失われても `imageDataUrl` で画像表示できるようフォールバック順序を改善
- 空 `src` 警告を修正

## 現在の永続化方式

| 方式 | 状態 |
|------|------|
| ATProto blob | PDS が保持しないため無効 |
| data URL | 確実に永続化される |
| メモリキャッシュ | 同一セッション内の即時表示用 |

Closes #127