### PR TITLE
feat(ci): GitHub Actions デプロイワークフローを追加 (ANA-102)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,31 @@
+name: Deploy to Production
+
+on:
+  push:
+    branches:
+      - release
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          script_stop: true
+          script: |
+            set -e
+            cd /opt/conversensus
+            git fetch origin
+            git checkout -B release origin/release
+            bun install --frozen-lockfile
+            bun run --cwd src/client build
+            cp -r src/client/dist/* /var/www/conversensus/
+            systemctl restart conversensus
+            echo "Deploy complete: $(date)"


### PR DESCRIPTION
## Summary

- `release` ブランチへの push / `workflow_dispatch` (手動) で VPS に自動デプロイ
- `appleboy/ssh-action` で SSH 接続し、VPS 上でビルド・配信・再起動を実行

## デプロイフロー

```
release ブランチへ push
  → GitHub Actions 起動
  → SSH で VPS 接続
  → git fetch & checkout release
  → bun install --frozen-lockfile
  → bun run --cwd src/client build
  → cp -r src/client/dist/* /var/www/conversensus/
  → systemctl restart conversensus
```

## 必要な GitHub Secrets (事前設定が必要)

| Secret | 内容 |
|--------|------|
| `VPS_HOST` | VPS の IP またはホスト名 |
| `VPS_USER` | SSH ユーザー名 |
| `VPS_SSH_KEY` | SSH 秘密鍵 (全文) |

## マージ後の手順

1. `main` から `release` ブランチを作成して push → 初回デプロイが自動実行される
   ```bash
   git checkout main
   git checkout -b release
   git push -u origin release
   ```
2. 以降は `main` → `release` への PR merge がデプロイトリガーになる

## Test plan

- [ ] PR を main にマージ
- [ ] `release` ブランチを作成して push
- [ ] GitHub Actions の実行ログを確認
- [ ] `https://app.conversensus.site` で最新版が反映されていることを確認

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)