### PR TITLE
Phase 0: O3 spike — ブランチ=操作ログの分岐 (Go 判定)

### DIFF
--- a/deepse/spikes/o3-report.md
+++ b/deepse/spikes/o3-report.md
@@ -1,0 +1,49 @@
+# O3 Spike レポート: ブランチ = 操作ログの分岐
+
+> 日付: 2026-07-12 / Phase: 0 ([step1 実装計画](../plans/step1-implementation.md))
+> PoC: `src/client/src/spikes/o3/branchAsLog.ts` + `.spike.test.ts` (投棄前提)
+
+## 判定: ✅ **Go**
+
+仮説「ブランチ = base offset + 追記イベント列 / コミット = ラベル付きオフセット / マージ = ブランチ ops を trunk へ追記し D7 ルールで解決」は成立する。最大リスクと見ていた**複合イベント (group/paste) の sync 語彙への載せ替えも分解で成立**したため、Partial ではなく Go。
+
+Phase 1 (統一語彙) に進んでよい。
+
+## 検証タスクの結果
+
+| # | 検証 | 結果 |
+|---|---|---|
+| 1 | base + 追記列からブランチ sheet を projection | ✅ `project()` が clock 昇順の畳み込みで状態を導出。base とブランチ ops の連結だけでブランチ状態が得られる |
+| 2 | マージ: structure=OR-Set / content=対立検出 / layout=静かな LWW | ✅ content の並行変更を 1 件の Conflict として検出しつつ LWW 確定。layout は Conflict に入れず LWW のみ。新規ノードはマージ後も保持 |
+| 3 | 複合イベント (group/paste) を基本 op 列に分解 | ✅ `decomposeGroup` = node.add(group)+layout.set+N×node.setParent、`decomposePaste` = N×node.add+M×edge.add。projection で復元 |
+| 4 | branchState.ts の解体マップ | 下表 |
+
+## branchState.ts (969行) 解体マップ
+
+現行は**レコード複製方式** (rkey `trunk_`/`{branchId}_`)。イベントログ分岐へ移す際の 13 公開関数 + 定数の仕分け:
+
+| 現行シンボル | 分類 | 移行方針 |
+|---|---|---|
+| `computeOperations` | **残す (要拡張)** | state diff → ops は UI diff 表示に有用。**layout を含めるよう拡張** (D7、現状 L102 で除外) |
+| `BRANCH_STATUS` / `Branch` / `Commit` 型 | **残す (再定義)** | ブランチ lifecycle は継続。`Commit` に log offset (clock) を持たせ、`Branch` = base + ops へ再定義 |
+| `fetchBranchesForSheet` | 退避 | PDS I/O → sync-provider (branch メタの pull) |
+| `fetchCommitsForBranch` | 退避 | PDS I/O → sync-provider (commit メタの pull) |
+| `updateBranchStatus` | 退避 | branch メタ更新 → sync-provider |
+| `createMergeRecord` | 退避 | merge マーカー書き込み → sync-provider |
+| `fetchBranchSheetFromPds` | **廃棄** | ブランチ sheet はログの projection。PDS からのレコード読みは event pull に置換 |
+| `syncBranchSheetToAtproto` | **廃棄** | rkey プレフィックス付きレコード書き込み → `push(events)` に置換 |
+| `mergeBranchToTrunk` | **廃棄** | レコード複製マージ → ログマージ (本 PoC の `merge`) に置換 |
+| `createMainBranch` | **廃棄** | trunk レコード生成 → ログ初期化に読み替え |
+| `createBranch` | **廃棄** | レコード複製でブランチ生成 → base offset の記録のみに |
+| `deleteBranchWithRecords` | **廃棄** | プレフィックス付きレコード一括削除 → 不要 (レコード複製をやめるため) |
+| `createCommit` | **概念維持・再ホーム** | commit = ラベル付きオフセット。メタ書き込みは sync-provider へ |
+
+→ **7 関数を廃棄、4 関数を sync-provider へ退避、`computeOperations` + 型のみ残す**。既存 PDS データ破棄前提のため、廃棄関数の移行コードは不要。
+
+## Phase 1 に引き継ぐ課題 (spike で顕在化)
+
+1. **Lamport clock の実装**: 発番は `++c` の簡易版。実装では受信時に `clock = max(local, remote) + 1` が必要。
+2. **add-wins OR-Set の厳密化**: 現 projection は structure も clock-LWW。concurrent add/remove の add-wins は本 spike 未検証 → Phase 1 で厳密化。
+3. **`computeOperations` の layout 対応** (D7)。
+4. **`applyEvent` の `EDGE_PROPERTIES_CHANGED` が現状 no-op** (applyEvent.ts:273)。統一時に実装を補う。
+5. **複合イベントを「分解して保存」か「複合のまま保存し projection 時に展開」か**: PoC は前者。undo/redo の粒度 (ユーザーの1操作=1 undo) を保つには後者が有利な場面がある → Phase 1 で語彙設計時に決定。

--- a/src/client/src/spikes/o3/branchAsLog.spike.test.ts
+++ b/src/client/src/spikes/o3/branchAsLog.spike.test.ts
@@ -1,0 +1,204 @@
+/**
+ * O3 Spike の実証テスト (投棄前提)
+ *
+ * Go 判定基準を1本ずつ確認する:
+ *   1. ブランチ projection    — base offset + 追記列から状態を導出できる
+ *   2. マージ + layout        — content=対立検出 / layout=静かな LWW / structure=OR-Set
+ *   3. 複合イベントの分解      — group / paste を基本 op 列に載せられる
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+  type Branch,
+  type Category,
+  type Commit,
+  decomposeGroup,
+  decomposePaste,
+  type Event,
+  type EventMeta,
+  merge,
+  project,
+} from './branchAsLog';
+
+// clock を単調増加させる簡易 Lamport 発番器
+function makeClock(start = 0) {
+  let c = start;
+  return (actor: string) =>
+    (category: Category): EventMeta => ({
+      id: crypto.randomUUID(),
+      actor,
+      clock: ++c,
+      category,
+    });
+}
+
+describe('O3 spike: branch = operation log divergence', () => {
+  test('1. ブランチ projection: base + 追記列から状態を導出できる', () => {
+    const tick = makeClock();
+    const meta = tick('local');
+
+    // trunk: A, B, A→B
+    const base: Event[] = [
+      {
+        ...meta('structure'),
+        op: { kind: 'node.add', target: 'A', content: 'a' },
+      },
+      {
+        ...meta('structure'),
+        op: { kind: 'node.add', target: 'B', content: 'b' },
+      },
+      {
+        ...meta('structure'),
+        op: { kind: 'edge.add', target: 'E', source: 'A', dest: 'B' },
+      },
+    ];
+    const baseCommit: Commit = { id: 'c0', message: 'base', clock: 3 };
+
+    // branch: A のラベル変更 + C 追加 + A の移動
+    const branch: Branch = {
+      id: 'br1',
+      base: baseCommit,
+      ops: [
+        {
+          ...meta('content'),
+          op: { kind: 'node.setContent', target: 'A', content: 'a-branch' },
+        },
+        {
+          ...meta('structure'),
+          op: { kind: 'node.add', target: 'C', content: 'c' },
+        },
+        {
+          ...meta('layout'),
+          op: { kind: 'layout.set', target: 'A', x: 100, y: 0 },
+        },
+      ],
+    };
+
+    // ブランチの状態 = base + branch.ops を畳み込む
+    const state = project([...base, ...branch.ops]);
+
+    expect(state.nodes.get('A')?.content).toBe('a-branch');
+    expect(state.nodes.has('C')).toBe(true);
+    expect(state.layout.get('A')).toEqual({
+      x: 100,
+      y: 0,
+      w: undefined,
+      h: undefined,
+    });
+    expect([...state.edges.keys()]).toEqual(['E']);
+  });
+
+  test('2. マージ: content=対立検出 / layout=静かな LWW / structure=OR-Set', () => {
+    const tick = makeClock();
+
+    // base
+    const base: Event[] = [
+      {
+        ...tick('local')('structure'),
+        op: { kind: 'node.add', target: 'A', content: 'a' },
+      },
+    ];
+
+    // trunk が base 以降に A を編集 (content と layout の両方)
+    const trunkAfterBase: Event[] = [
+      {
+        ...tick('alice')('content'),
+        op: { kind: 'node.setContent', target: 'A', content: 'a-trunk' },
+      },
+      {
+        ...tick('alice')('layout'),
+        op: { kind: 'layout.set', target: 'A', x: 10, y: 10 },
+      },
+    ];
+
+    // branch も同じ A を別方向に編集 + 新規ノード D 追加
+    const branch: Branch = {
+      id: 'br',
+      base: { id: 'c0', message: 'base', clock: 1 },
+      ops: [
+        {
+          ...tick('bob')('content'),
+          op: { kind: 'node.setContent', target: 'A', content: 'a-branch' },
+        },
+        {
+          ...tick('bob')('layout'),
+          op: { kind: 'layout.set', target: 'A', x: 99, y: 99 },
+        },
+        {
+          ...tick('bob')('structure'),
+          op: { kind: 'node.add', target: 'D', content: 'd' },
+        },
+      ],
+    };
+
+    const { merged, conflicts } = merge(trunkAfterBase, branch);
+    const state = project([...base, ...merged]);
+
+    // content: 対立が1件検出される (合意形成の機会として可視化する候補)
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].category).toBe('content');
+    expect(conflicts[0].target).toBe('A');
+
+    // content: LWW で暫定確定 (clock が大きい branch 側 'a-branch')
+    expect(state.nodes.get('A')?.content).toBe('a-branch');
+
+    // layout: 静かな LWW。clock 最大の branch 値。対立には含めない
+    expect(state.layout.get('A')).toEqual({
+      x: 99,
+      y: 99,
+      w: undefined,
+      h: undefined,
+    });
+    expect(conflicts.some((c) => c.category === 'layout')).toBe(false);
+
+    // structure: OR-Set。新規 D はマージ後も存在
+    expect(state.nodes.has('D')).toBe(true);
+  });
+
+  test('3. 複合イベント: group / paste を基本 op 列に分解して projection できる', () => {
+    const tick = makeClock();
+    const meta = tick('local');
+
+    // 既存ノード X, Y を group 化
+    const seed: Event[] = [
+      {
+        ...meta('structure'),
+        op: { kind: 'node.add', target: 'X', content: 'x' },
+      },
+      {
+        ...meta('structure'),
+        op: { kind: 'node.add', target: 'Y', content: 'y' },
+      },
+    ];
+    const groupOps = decomposeGroup(
+      'G',
+      ['X', 'Y'],
+      { x: 0, y: 0, w: 200, h: 200 },
+      meta,
+    );
+
+    const grouped = project([...seed, ...groupOps]);
+    expect(grouped.nodes.get('G')?.isGroup).toBe(true);
+    expect(grouped.nodes.get('X')?.parent).toBe('G');
+    expect(grouped.nodes.get('Y')?.parent).toBe('G');
+    expect(grouped.layout.get('G')).toEqual({ x: 0, y: 0, w: 200, h: 200 });
+
+    // paste: 2 ノード + 1 エッジ
+    const pasteOps = decomposePaste(
+      [
+        { id: 'P1', content: 'p1' },
+        { id: 'P2', content: 'p2' },
+      ],
+      [{ id: 'PE', source: 'P1', dest: 'P2' }],
+      meta,
+    );
+    const pasted = project([...seed, ...groupOps, ...pasteOps]);
+    expect(pasted.nodes.has('P1')).toBe(true);
+    expect(pasted.nodes.has('P2')).toBe(true);
+    expect(pasted.edges.get('PE')).toEqual({
+      id: 'PE',
+      source: 'P1',
+      dest: 'P2',
+    });
+  });
+});

--- a/src/client/src/spikes/o3/branchAsLog.ts
+++ b/src/client/src/spikes/o3/branchAsLog.ts
@@ -1,0 +1,265 @@
+/**
+ * O3 Spike — 「ブランチ = 操作ログの分岐」の実現可能性 PoC (投棄前提)
+ *
+ * 検証する仮説:
+ *   - ブランチ    = base offset (commit) + 追記イベント列
+ *   - コミット    = 操作ログ上のラベル付きオフセット
+ *   - マージ      = ブランチ ops を trunk へ追記し、D7 のルールで解決
+ *       - structure (add/remove) : OR-Set (add-wins)
+ *       - content   (update)     : LWW + 衝突を「対立」として検出・保持
+ *       - layout                 : LWW (静かに解決、対立にしない)
+ *   - 複合イベント (group/paste) : 基本 op 列へ分解して sync 語彙に乗せる
+ *
+ * PDS 非依存・完全ローカル。実 app 型には依存しない (spike の独立性のため)。
+ */
+
+// --- 統一イベント語彙 (スケッチ) ---
+
+export type Lamport = number;
+export type Actor = string; // DID or 'local'
+export type Category = 'structure' | 'content' | 'layout' | 'presentation';
+
+/** 全イベント共通のメタ (step1 §4「イベントの最小要件」に対応) */
+export type EventMeta = {
+  id: string;
+  actor: Actor;
+  clock: Lamport; // 論理時刻 (Lamport) — LWW の順序付けに使用
+  category: Category;
+};
+
+export type Op =
+  // structure
+  | { kind: 'node.add'; target: string; content: string; isGroup?: boolean }
+  | { kind: 'node.remove'; target: string }
+  | { kind: 'node.setParent'; target: string; parent?: string }
+  | { kind: 'edge.add'; target: string; source: string; dest: string }
+  | { kind: 'edge.remove'; target: string }
+  // content
+  | { kind: 'node.setContent'; target: string; content: string }
+  | { kind: 'edge.setLabel'; target: string; label: string }
+  // layout
+  | {
+      kind: 'layout.set';
+      target: string;
+      x?: number;
+      y?: number;
+      w?: number;
+      h?: number;
+    };
+
+export type Event = EventMeta & { op: Op };
+
+/** コミット = 操作ログ上のラベル付きオフセット */
+export type Commit = { id: string; message: string; clock: Lamport };
+
+/** ブランチ = base コミット + そこから追記されたイベント列 */
+export type Branch = { id: string; base: Commit; ops: Event[] };
+
+// --- projection: 操作ログ → 状態 ---
+
+export type NodeState = {
+  id: string;
+  content: string;
+  isGroup: boolean;
+  parent?: string;
+};
+export type EdgeState = {
+  id: string;
+  source: string;
+  dest: string;
+  label?: string;
+};
+export type LayoutState = { x?: number; y?: number; w?: number; h?: number };
+
+export type GraphState = {
+  nodes: Map<string, NodeState>;
+  edges: Map<string, EdgeState>;
+  layout: Map<string, LayoutState>;
+};
+
+const emptyState = (): GraphState => ({
+  nodes: new Map(),
+  edges: new Map(),
+  layout: new Map(),
+});
+
+/** イベント列を clock 昇順で畳み込み、状態を導出する (fold / applyEvent の統一版) */
+export function project(events: Event[]): GraphState {
+  const state = emptyState();
+  const ordered = [...events].sort((a, b) => a.clock - b.clock);
+  for (const ev of ordered) {
+    applyOp(state, ev.op);
+  }
+  return state;
+}
+
+function applyOp(state: GraphState, op: Op): void {
+  switch (op.kind) {
+    case 'node.add':
+      state.nodes.set(op.target, {
+        id: op.target,
+        content: op.content,
+        isGroup: op.isGroup ?? false,
+      });
+      break;
+    case 'node.remove':
+      state.nodes.delete(op.target);
+      break;
+    case 'node.setParent': {
+      const n = state.nodes.get(op.target);
+      if (n) n.parent = op.parent;
+      break;
+    }
+    case 'node.setContent': {
+      const n = state.nodes.get(op.target);
+      if (n) n.content = op.content;
+      break;
+    }
+    case 'edge.add':
+      state.edges.set(op.target, {
+        id: op.target,
+        source: op.source,
+        dest: op.dest,
+      });
+      break;
+    case 'edge.remove':
+      state.edges.delete(op.target);
+      break;
+    case 'edge.setLabel': {
+      const e = state.edges.get(op.target);
+      if (e) e.label = op.label;
+      break;
+    }
+    case 'layout.set':
+      state.layout.set(op.target, { x: op.x, y: op.y, w: op.w, h: op.h });
+      break;
+  }
+}
+
+// --- マージ ---
+
+export type Conflict = {
+  target: string;
+  category: Category;
+  ours: Event;
+  theirs: Event;
+};
+
+export type MergeResult = {
+  merged: Event[]; // trunk へ追記される、解決済みイベント列
+  conflicts: Conflict[]; // content の対立 (グラフ上に可視化する候補)
+};
+
+/**
+ * base 以降の trunk 変更 ( trunkAfterBase) と branch の変更をマージする。
+ *
+ * - structure add/remove : 両者の op を追記し clock 順に畳み込む。
+ *   concurrent add/remove の add-wins OR-Set 厳密化は Phase 1 の課題 (本 spike は未検証)。
+ * - content update       : 同一 target への並行変更を LWW で確定しつつ Conflict に記録。
+ * - layout               : LWW (clock 大が勝つ)。Conflict には記録しない。
+ */
+export function merge(trunkAfterBase: Event[], branch: Branch): MergeResult {
+  const merged: Event[] = [...trunkAfterBase];
+  const conflicts: Conflict[] = [];
+
+  // trunk 側の「target ごとの最後の content / layout 変更」を引く索引
+  const trunkContent = lastByTarget(trunkAfterBase, 'content');
+  const trunkLayout = lastByTarget(trunkAfterBase, 'layout');
+
+  for (const ev of branch.ops) {
+    if (ev.category === 'content') {
+      const target = opTarget(ev.op);
+      const rival = trunkContent.get(target);
+      if (rival && differs(rival, ev)) {
+        // 並行 content 変更 = 対立。LWW で確定しつつ可視化候補に積む
+        conflicts.push({
+          target,
+          category: 'content',
+          ours: rival,
+          theirs: ev,
+        });
+      }
+      merged.push(ev); // clock 順で project すれば LWW が成立
+    } else if (ev.category === 'layout') {
+      // layout は LWW のみ。対立にしない (D7)
+      const target = opTarget(ev.op);
+      const rival = trunkLayout.get(target);
+      if (!rival || ev.clock > rival.clock) merged.push(ev);
+    } else {
+      // structure (add/remove/parent) : 追記して clock 順に畳み込む
+      // (concurrent add/remove の add-wins 厳密化は Phase 1)
+      merged.push(ev);
+    }
+  }
+
+  return { merged, conflicts };
+}
+
+function lastByTarget(events: Event[], category: Category): Map<string, Event> {
+  const m = new Map<string, Event>();
+  for (const ev of events) {
+    if (ev.category !== category) continue;
+    const target = opTarget(ev.op);
+    const prev = m.get(target);
+    if (!prev || ev.clock > prev.clock) m.set(target, ev);
+  }
+  return m;
+}
+
+function opTarget(op: Op): string {
+  return op.target;
+}
+
+function differs(a: Event, b: Event): boolean {
+  return JSON.stringify(a.op) !== JSON.stringify(b.op);
+}
+
+// --- 複合イベントの分解 (group / paste) ---
+
+/** グループ化 = group ノード追加 + 子の親付け替え + group の layout */
+export function decomposeGroup(
+  groupId: string,
+  childIds: string[],
+  groupLayout: LayoutState,
+  meta: (category: Category) => EventMeta,
+): Event[] {
+  const events: Event[] = [
+    {
+      ...meta('structure'),
+      op: { kind: 'node.add', target: groupId, content: '', isGroup: true },
+    },
+    {
+      ...meta('layout'),
+      op: { kind: 'layout.set', target: groupId, ...groupLayout },
+    },
+  ];
+  for (const childId of childIds) {
+    events.push({
+      ...meta('structure'),
+      op: { kind: 'node.setParent', target: childId, parent: groupId },
+    });
+  }
+  return events;
+}
+
+/** ペースト = 複数の node.add + edge.add */
+export function decomposePaste(
+  nodes: Array<{ id: string; content: string }>,
+  edges: Array<{ id: string; source: string; dest: string }>,
+  meta: (category: Category) => EventMeta,
+): Event[] {
+  const events: Event[] = [];
+  for (const n of nodes) {
+    events.push({
+      ...meta('structure'),
+      op: { kind: 'node.add', target: n.id, content: n.content },
+    });
+  }
+  for (const e of edges) {
+    events.push({
+      ...meta('structure'),
+      op: { kind: 'edge.add', target: e.id, source: e.source, dest: e.dest },
+    });
+  }
+  return events;
+}


### PR DESCRIPTION
## 概要

step1 実装計画の **Phase 0 (O3 spike)**。「branch/commit/merge を統一イベントモデル (操作ログ) に載せ替えられるか」を PDS 非依存の最小 PoC で検証した。

**判定: ✅ Go** — Phase 1 (統一語彙) へ進んでよい。

## 検証結果

| 検証 | 結果 |
|---|---|
| ブランチ projection (base + 追記列 → 状態) | ✅ |
| マージ (structure=OR-Set / content=対立検出 / layout=静かな LWW) | ✅ |
| 複合イベント (group/paste) の基本 op 列への分解 | ✅ (最大リスクだったが成立) |
| branchState.ts (969行) の解体マップ | 7廃棄 / 4退避 / computeOperations拡張 |

詳細: `deepse/spikes/o3-report.md`

## 成果物

- `src/client/src/spikes/o3/branchAsLog.ts` — 統一語彙スケッチ + projection/merge/decompose (**投棄前提**)
- `src/client/src/spikes/o3/branchAsLog.spike.test.ts` — Go 基準の実証 (3 test)
- `deepse/spikes/o3-report.md` — 判定レポート + 解体マップ + Phase 1 引き継ぎ課題

## レビュー観点

- PoC のモデル (branch=base+ops, merge の D7 ルール) が Phase 1 の実設計として妥当か
- branchState.ts 解体マップの仕分け (廃棄/退避/残す) に異論がないか

PoC コードは Phase 1 で実型 (`GraphEvent` 統合) に置換して削除する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)