### PR TITLE
Phase 1: 統一イベント語彙 + projection

### DIFF
--- a/deepse/plans/step1-implementation.md
+++ b/deepse/plans/step1-implementation.md
@@ -90,6 +90,21 @@ branch: "{branchId}_{uuid}"
 
 | ID | 未決 | 決定タイミング |
 |---|---|---|
-| 論理時刻の実体 | Lamport / wall-clock / hybrid。LWW の順序付けに使用 | Phase 1 冒頭 (Lamport 推奨) |
+| ~~論理時刻の実体~~ | **確定: Lamport** (`LamportClock`, observe=max+1)。Phase 1 で実装 | ✅ Phase 1 |
 | O1 ストレージ実体 | JSON / SQLite / IndexedDB | Phase 3 冒頭。O2 (配布形態) と連動 |
-| 複合イベントの正規化 | grouping/paste を基本 ops に分解するか複合で運ぶか | Phase 0 の結論次第 |
+| ~~複合イベントの正規化~~ | **確定: バッチ** (1 操作 = 基本 op のバッチ, undo 単位 = バッチ, 解決単位 = op) | ✅ Phase 1 |
+
+## 5. Phase 1 完了メモ (2026-07-12)
+
+- **成果物** (`src/shared/src/events/`, `src/client/src/events/toUnified.ts`):
+  - `unified.ts`: 統一語彙 (Op 15 種 / Batch / OP_CATEGORY / isSyncable / LamportClock)。
+  - `project.ts`: `projectBatches` (fold) + `toSheet`。LWW・カスケード削除・layout 部分更新・presentation 分離。
+  - `fromCommitOperation.ts`: `CommitOperation` (6 種) → Op[] 。同期語彙の部分集合性を証明。
+  - `toUnified.ts`: `GraphEvent` (19 種) → Batch。client 語彙の部分集合性を証明。複合イベントをバッチ分解。
+- **layout を語彙に内包** (D7): `node.setLayout` / `edge.setLayout` を同期対象 op として定義。
+- **テスト**: 20 追加 (全 326 pass)。各 `.test.md` あり。
+- **Phase 2 へ引き継ぐ既知の制約**:
+  1. `NODE_PROPERTIES_CHANGED.to` は差分 → 統一 op は置換意味論。capture 時に full properties を持たせる配線が必要。
+  2. `NODE_STYLE_CHANGED` を layout へ正規化した。旧イベント発行箇所の整理は Phase 2。
+  3. 本 Phase は**追加のみ (非破壊)**。既存 `GraphEvent`/`CommitOperation` の呼び出し箇所の実置換は Phase 2 以降。
+  4. add-wins OR-Set の厳密化 (concurrent add/remove) は未実装 (現 projection は clock-LWW)。

--- a/src/client/src/events/toUnified.test.md
+++ b/src/client/src/events/toUnified.test.md
@@ -1,0 +1,22 @@
+# toUnified.test.ts — GraphEvent エンコーダのテスト仕様
+
+## 何を
+
+`toUnified.ts` の `graphEventToOps` / `graphEventToBatch` を検証する。
+
+## なぜ
+
+現行 client 語彙 `GraphEvent` (19 種) が統一語彙の **部分集合**であることを保証する。特にバッチモデル (deep-interview で確定) の要である「複合イベントの基本 op への分解」が正しいことを固定する。これが崩れると undo/redo と同期の両立が破綻する。
+
+## どのように
+
+- **複合イベントの分解**:
+  - `NODES_GROUPED` → group ノードの node.add + layout + 子ごとの setParent/setLayout に分解され、子を先に追加した状態で畳み込むと親子関係が復元されることを確認する。
+  - `NODE_REPARENTED` → setParent (structure) + setLayout (layout) の 2 op に分かれることを確認する (親変更と位置変更は別カテゴリ)。
+- **19 型の網羅**: 全 19 イベント型の最小インスタンスを用意し、(a) 型集合が 19 であること、(b) 各イベントが 1 つ以上の op に分解されることを確認する。新しいイベント型を追加してエンコーダ対応を忘れると気づける「番人」。
+- **メタの写像**: `graphEventToBatch` が event.id → BatchId、userId → actor、指定 clock を Batch に写すことを確認する。
+
+## 既知の制約 (テスト対象外・Phase 2 で解消)
+
+- `NODE_PROPERTIES_CHANGED.to` は差分だが統一 op は置換意味論。忠実変換には capture 時の full properties が必要。
+- `NODE_STYLE_CHANGED` は width/height 変更の実体を持つため layout に正規化している。

--- a/src/client/src/events/toUnified.test.ts
+++ b/src/client/src/events/toUnified.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  type EdgeId,
+  EdgeIdSchema,
+  type NodeId,
+  NodeIdSchema,
+  projectBatches,
+} from '@conversensus/shared';
+import type { GraphEvent } from './GraphEvent';
+import { makeEventBase } from './GraphEvent';
+import { graphEventToBatch, graphEventToOps } from './toUnified';
+
+const nid = (): NodeId => NodeIdSchema.parse(crypto.randomUUID());
+const eid = (): EdgeId => EdgeIdSchema.parse(crypto.randomUUID());
+
+describe('graphEventToOps: 複合イベントの分解', () => {
+  test('NODES_GROUPED → group 追加 + layout + 子ごとの setParent/setLayout', () => {
+    const parentId = nid();
+    const childA = nid();
+    const childB = nid();
+    const event: GraphEvent = {
+      ...makeEventBase('structure'),
+      type: 'NODES_GROUPED',
+      parentId,
+      parentData: { id: parentId, content: '', nodeType: 'group' },
+      parentLayout: { nodeId: parentId, x: 0, y: 0, width: 200, height: 200 },
+      children: [
+        {
+          nodeId: childA,
+          originalParentId: undefined,
+          originalPosition: { x: 5, y: 5 },
+          newPosition: { x: 10, y: 10 },
+        },
+        {
+          nodeId: childB,
+          originalParentId: undefined,
+          originalPosition: { x: 6, y: 6 },
+          newPosition: { x: 20, y: 20 },
+        },
+      ],
+    };
+    const ops = graphEventToOps(event);
+    expect(ops[0]).toMatchObject({
+      kind: 'node.add',
+      target: parentId,
+      nodeType: 'group',
+    });
+    expect(ops.filter((o) => o.kind === 'node.setParent')).toHaveLength(2);
+    // 子を先に追加した状態でグループ化を畳み込むと親子関係が復元される
+    const seed: GraphEvent = {
+      ...makeEventBase('structure'),
+      type: 'NODES_PASTED',
+      nodes: [
+        { id: childA, content: 'a' },
+        { id: childB, content: 'b' },
+      ],
+      layouts: [],
+      edges: [],
+      edgeLayouts: [],
+    };
+    const g = projectBatches([
+      graphEventToBatch(seed, 1),
+      graphEventToBatch(event, 2),
+    ]);
+    expect(g.nodes.get(parentId)?.nodeType).toBe('group');
+    expect(g.nodes.get(childA)?.parentId).toBe(parentId);
+  });
+
+  test('NODE_REPARENTED → setParent + setLayout の 2 op', () => {
+    const nodeId = nid();
+    const newParent = nid();
+    const event: GraphEvent = {
+      ...makeEventBase('structure'),
+      type: 'NODE_REPARENTED',
+      nodeId,
+      oldParentId: undefined,
+      newParentId: newParent,
+      oldPosition: { x: 0, y: 0 },
+      newPosition: { x: 50, y: 60 },
+    };
+    const ops = graphEventToOps(event);
+    expect(ops.map((o) => o.kind)).toEqual([
+      'node.setParent',
+      'node.setLayout',
+    ]);
+  });
+});
+
+describe('graphEventToOps: 全 19 イベント型を網羅する', () => {
+  // 各型の最小構成インスタンス。新しい型を追加したらここに足す (網羅性の番人)
+  const nodeId = nid();
+  const edgeId = eid();
+  const events: GraphEvent[] = [
+    {
+      ...makeEventBase('structure'),
+      type: 'NODE_ADDED',
+      nodeId,
+      data: { id: nodeId, content: 'A' },
+      layout: { nodeId, x: 0, y: 0 },
+    },
+    {
+      ...makeEventBase('structure'),
+      type: 'NODE_DELETED',
+      nodeId,
+      data: { id: nodeId, content: 'A' },
+    },
+    {
+      ...makeEventBase('structure'),
+      type: 'EDGE_ADDED',
+      edgeId,
+      data: { id: edgeId, source: nid(), target: nid() },
+    },
+    {
+      ...makeEventBase('structure'),
+      type: 'EDGE_DELETED',
+      edgeId,
+      data: { id: edgeId, source: nid(), target: nid() },
+    },
+    {
+      ...makeEventBase('structure'),
+      type: 'EDGE_RECONNECTED',
+      edgeId,
+      from: { source: nid(), target: nid() },
+      to: { source: nid(), target: nid() },
+    },
+    {
+      ...makeEventBase('structure'),
+      type: 'NODE_REPARENTED',
+      nodeId,
+      oldParentId: undefined,
+      newParentId: nid(),
+      oldPosition: { x: 0, y: 0 },
+      newPosition: { x: 1, y: 1 },
+    },
+    {
+      ...makeEventBase('structure'),
+      type: 'NODES_GROUPED',
+      parentId: nodeId,
+      parentData: { id: nodeId, content: '' },
+      parentLayout: { nodeId },
+      children: [],
+    },
+    {
+      ...makeEventBase('structure'),
+      type: 'NODES_UNGROUPED',
+      parentId: nodeId,
+      parentData: { id: nodeId, content: '' },
+      parentLayout: { nodeId },
+      children: [
+        {
+          nodeId: nid(),
+          originalParentId: undefined,
+          originalPosition: { x: 0, y: 0 },
+          newPosition: { x: 0, y: 0 },
+        },
+      ],
+    },
+    {
+      ...makeEventBase('structure'),
+      type: 'NODES_PASTED',
+      nodes: [{ id: nid(), content: 'P' }],
+      layouts: [],
+      edges: [],
+      edgeLayouts: [],
+    },
+    {
+      ...makeEventBase('structure'),
+      type: 'NODES_PASTED_UNDO',
+      nodeIds: [nid()],
+      edgeIds: [eid()],
+      nodes: [],
+      layouts: [],
+      edges: [],
+      edgeLayouts: [],
+    },
+    {
+      ...makeEventBase('content'),
+      type: 'NODE_RELABELED',
+      nodeId,
+      from: 'a',
+      to: 'b',
+    },
+    {
+      ...makeEventBase('content'),
+      type: 'EDGE_RELABELED',
+      edgeId,
+      from: 'a',
+      to: 'b',
+    },
+    {
+      ...makeEventBase('content'),
+      type: 'NODE_PROPERTIES_CHANGED',
+      nodeId,
+      from: {},
+      to: { k: 1 },
+    },
+    {
+      ...makeEventBase('content'),
+      type: 'EDGE_PROPERTIES_CHANGED',
+      edgeId,
+      from: {},
+      to: { k: 1 },
+    },
+    {
+      ...makeEventBase('layout'),
+      type: 'NODE_MOVED',
+      nodeId,
+      from: { x: 0, y: 0 },
+      to: { x: 1, y: 1 },
+    },
+    {
+      ...makeEventBase('layout'),
+      type: 'NODE_RESIZED',
+      nodeId,
+      from: { width: 1, height: 1 },
+      to: { width: 2, height: 2 },
+    },
+    {
+      ...makeEventBase('presentation'),
+      type: 'EDGE_STYLE_CHANGED',
+      edgeId,
+      from: {},
+      to: { stroke: 'red' },
+    },
+    {
+      ...makeEventBase('presentation'),
+      type: 'NODE_STYLE_CHANGED',
+      nodeId,
+      from: { nodeId },
+      to: { nodeId, width: 10, height: 10 },
+    },
+    {
+      ...makeEventBase('presentation'),
+      type: 'EDGE_LABEL_MOVED',
+      edgeId,
+      from: { offsetX: 0, offsetY: 0 },
+      to: { offsetX: 5, offsetY: 5 },
+    },
+  ];
+
+  test('19 型すべてを用意している', () => {
+    const types = new Set(events.map((e) => e.type));
+    expect(types.size).toBe(19);
+  });
+
+  test('各イベントが 1 つ以上の op に分解される', () => {
+    for (const event of events) {
+      expect(graphEventToOps(event).length).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  test('graphEventToBatch は event.id を BatchId に、userId を actor にする', () => {
+    const event = events[0];
+    const batch = graphEventToBatch(event, 7);
+    expect(batch.id).toBe(event.id);
+    expect(batch.actor).toBe(event.userId);
+    expect(batch.clock).toBe(7);
+  });
+});

--- a/src/client/src/events/toUnified.ts
+++ b/src/client/src/events/toUnified.ts
@@ -1,0 +1,290 @@
+/**
+ * GraphEvent → 統一イベント (Batch) のエンコーダ
+ *
+ * 現行 client 語彙 `GraphEvent` (19 種) が統一語彙の部分集合であることを示す。
+ * 複合イベント (NODES_GROUPED / NODES_PASTED / NODE_REPARENTED 等) は
+ * バッチモデルに従い、複数の基本 Op から成る 1 Batch に分解される。
+ *
+ * 既知の制約 (Phase 2 の配線で解消):
+ *   - NODE_PROPERTIES_CHANGED.to は差分 (delta) だが、統一 op `node.setProperties` は
+ *     置換 (full) 意味論。忠実な変換には capture 時に full properties が必要。
+ *   - NODE_STYLE_CHANGED は現状 presentation 分類だが、実体は width/height の変更なので
+ *     統一語彙では layout (`node.setLayout`) に正規化する (D7 の整理)。
+ */
+
+import type {
+  EdgeId,
+  EdgeLayout,
+  Lamport,
+  NodeId,
+  NodeLayout,
+} from '@conversensus/shared';
+import { type Batch, BatchIdSchema, type Op } from '@conversensus/shared';
+import type { GraphEvent } from './GraphEvent';
+
+function nodeLayoutOp(nodeId: NodeId, layout: NodeLayout | undefined): Op[] {
+  if (!layout) return [];
+  const { x, y, width, height } = layout;
+  if (
+    x === undefined &&
+    y === undefined &&
+    width === undefined &&
+    height === undefined
+  )
+    return [];
+  return [
+    {
+      kind: 'node.setLayout',
+      target: nodeId,
+      ...(x !== undefined && { x }),
+      ...(y !== undefined && { y }),
+      ...(width !== undefined && { width }),
+      ...(height !== undefined && { height }),
+    },
+  ];
+}
+
+function edgeLayoutOp(edgeId: EdgeId, layout: EdgeLayout | undefined): Op[] {
+  if (!layout) return [];
+  const { sourceHandle, targetHandle, pathType } = layout;
+  if (
+    sourceHandle === undefined &&
+    targetHandle === undefined &&
+    pathType === undefined
+  )
+    return [];
+  return [
+    {
+      kind: 'edge.setLayout',
+      target: edgeId,
+      ...(sourceHandle !== undefined && { sourceHandle }),
+      ...(targetHandle !== undefined && { targetHandle }),
+      ...(pathType !== undefined && { pathType }),
+    },
+  ];
+}
+
+/** GraphEvent を、それを構成する基本 Op 列へ分解する */
+export function graphEventToOps(event: GraphEvent): Op[] {
+  switch (event.type) {
+    case 'NODE_ADDED':
+      return [
+        {
+          kind: 'node.add',
+          target: event.data.id,
+          content: event.data.content,
+          ...(event.data.properties && { properties: event.data.properties }),
+          ...(event.data.nodeType && { nodeType: event.data.nodeType }),
+          ...(event.data.parentId !== undefined && {
+            parentId: event.data.parentId,
+          }),
+        },
+        ...nodeLayoutOp(event.nodeId, event.layout),
+      ];
+    case 'NODE_DELETED':
+      return [{ kind: 'node.remove', target: event.nodeId }];
+    case 'EDGE_ADDED':
+      return [
+        {
+          kind: 'edge.add',
+          target: event.data.id,
+          source: event.data.source,
+          dest: event.data.target,
+          ...(event.data.label !== undefined && { label: event.data.label }),
+          ...(event.data.properties && { properties: event.data.properties }),
+        },
+        ...edgeLayoutOp(event.edgeId, event.edgeLayout),
+      ];
+    case 'EDGE_DELETED':
+      return [{ kind: 'edge.remove', target: event.edgeId }];
+    case 'EDGE_RECONNECTED':
+      return [
+        {
+          kind: 'edge.reconnect',
+          target: event.edgeId,
+          source: event.to.source,
+          dest: event.to.target,
+          ...(event.to.sourceHandle !== undefined && {
+            sourceHandle: event.to.sourceHandle,
+          }),
+          ...(event.to.targetHandle !== undefined && {
+            targetHandle: event.to.targetHandle,
+          }),
+        },
+      ];
+    case 'NODE_REPARENTED':
+      return [
+        {
+          kind: 'node.setParent',
+          target: event.nodeId,
+          ...(event.newParentId !== undefined && {
+            parentId: event.newParentId,
+          }),
+        },
+        {
+          kind: 'node.setLayout',
+          target: event.nodeId,
+          x: event.newPosition.x,
+          y: event.newPosition.y,
+        },
+      ];
+    case 'NODES_GROUPED': {
+      const ops: Op[] = [
+        {
+          kind: 'node.add',
+          target: event.parentId,
+          content: event.parentData.content,
+          ...(event.parentData.nodeType && {
+            nodeType: event.parentData.nodeType,
+          }),
+        },
+        ...nodeLayoutOp(event.parentId, event.parentLayout),
+      ];
+      for (const child of event.children) {
+        ops.push({
+          kind: 'node.setParent',
+          target: child.nodeId,
+          parentId: event.parentId,
+        });
+        ops.push({
+          kind: 'node.setLayout',
+          target: child.nodeId,
+          x: child.newPosition.x,
+          y: child.newPosition.y,
+        });
+      }
+      return ops;
+    }
+    case 'NODES_UNGROUPED': {
+      const ops: Op[] = [];
+      for (const child of event.children) {
+        ops.push({
+          kind: 'node.setParent',
+          target: child.nodeId,
+          ...(child.originalParentId !== undefined && {
+            parentId: child.originalParentId,
+          }),
+        });
+        ops.push({
+          kind: 'node.setLayout',
+          target: child.nodeId,
+          x: child.originalPosition.x,
+          y: child.originalPosition.y,
+        });
+      }
+      ops.push({ kind: 'node.remove', target: event.parentId });
+      return ops;
+    }
+    case 'NODES_PASTED': {
+      const ops: Op[] = [];
+      event.nodes.forEach((node, i) => {
+        ops.push({
+          kind: 'node.add',
+          target: node.id,
+          content: node.content,
+          ...(node.properties && { properties: node.properties }),
+          ...(node.nodeType && { nodeType: node.nodeType }),
+          ...(node.parentId !== undefined && { parentId: node.parentId }),
+        });
+        ops.push(...nodeLayoutOp(node.id, event.layouts[i]));
+      });
+      event.edges.forEach((edge, i) => {
+        ops.push({
+          kind: 'edge.add',
+          target: edge.id,
+          source: edge.source,
+          dest: edge.target,
+          ...(edge.label !== undefined && { label: edge.label }),
+          ...(edge.properties && { properties: edge.properties }),
+        });
+        ops.push(...edgeLayoutOp(edge.id, event.edgeLayouts[i]));
+      });
+      return ops;
+    }
+    case 'NODES_PASTED_UNDO': {
+      const ops: Op[] = [];
+      for (const edgeId of event.edgeIds)
+        ops.push({ kind: 'edge.remove', target: edgeId });
+      for (const nodeId of event.nodeIds)
+        ops.push({ kind: 'node.remove', target: nodeId });
+      return ops;
+    }
+    case 'NODE_RELABELED':
+      return [
+        { kind: 'node.setContent', target: event.nodeId, content: event.to },
+      ];
+    case 'EDGE_RELABELED':
+      return [{ kind: 'edge.setLabel', target: event.edgeId, label: event.to }];
+    case 'NODE_PROPERTIES_CHANGED':
+      return [
+        {
+          kind: 'node.setProperties',
+          target: event.nodeId,
+          properties: event.to,
+        },
+      ];
+    case 'EDGE_PROPERTIES_CHANGED':
+      return [
+        {
+          kind: 'edge.setProperties',
+          target: event.edgeId,
+          properties: event.to,
+        },
+      ];
+    case 'NODE_MOVED':
+      return [
+        {
+          kind: 'node.setLayout',
+          target: event.nodeId,
+          x: event.to.x,
+          y: event.to.y,
+        },
+      ];
+    case 'NODE_RESIZED':
+      return [
+        {
+          kind: 'node.setLayout',
+          target: event.nodeId,
+          width: event.to.width,
+          height: event.to.height,
+        },
+      ];
+    case 'NODE_STYLE_CHANGED': {
+      // 実体は width/height の変更 → layout に正規化する
+      const ops: Op[] = [];
+      const { width, height } = event.to;
+      if (width !== undefined || height !== undefined)
+        ops.push({
+          kind: 'node.setLayout',
+          target: event.nodeId,
+          ...(width !== undefined && { width }),
+          ...(height !== undefined && { height }),
+        });
+      return ops;
+    }
+    case 'EDGE_STYLE_CHANGED':
+      return [{ kind: 'edge.setStyle', target: event.edgeId, style: event.to }];
+    case 'EDGE_LABEL_MOVED':
+      return [
+        {
+          kind: 'edge.setLabelOffset',
+          target: event.edgeId,
+          offsetX: event.to.offsetX,
+          offsetY: event.to.offsetY,
+        },
+      ];
+    default:
+      return [];
+  }
+}
+
+/** GraphEvent を 1 つの Batch へ変換する (1 ユーザー操作 = 1 Batch) */
+export function graphEventToBatch(event: GraphEvent, clock: Lamport): Batch {
+  return {
+    id: BatchIdSchema.parse(event.id),
+    actor: event.userId,
+    clock,
+    timestamp: event.timestamp,
+    ops: graphEventToOps(event),
+  };
+}

--- a/src/shared/src/events/fromCommitOperation.test.md
+++ b/src/shared/src/events/fromCommitOperation.test.md
@@ -1,0 +1,15 @@
+# fromCommitOperation.test.ts — CommitOperation エンコーダのテスト仕様
+
+## 何を
+
+`fromCommitOperation.ts` の `commitOperationToOps` / `commitOperationsToBatch` を検証する。
+
+## なぜ
+
+step1 §4 の眼目は「二重定義の解消」。既存の同期語彙 `CommitOperation` (6 種) が統一語彙の **部分集合**であることを保証できて初めて、統一が「第三の表現の追加」ではなく「収れん」になる。この部分集合性を固定する。
+
+## どのように
+
+- **展開**: 1 つの `node.update` (content + properties + parentId) が setContent / setProperties / setParent の 3 op に展開されることを確認する。CommitOperation の update は複数の意味的変更を含みうるため。
+- **写像の単純性**: `edge.remove` が `edge.remove` op へ 1 対 1 で写ることを確認する。
+- **導出の一致**: CommitOperation 列を Batch 化して projection すると、期待どおりのグラフ状態 (最終 content・edge label 等) が得られることを確認する。同期語彙が統一語彙の中で正しく振る舞う証拠。

--- a/src/shared/src/events/fromCommitOperation.test.ts
+++ b/src/shared/src/events/fromCommitOperation.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test';
+import type { CommitOperation } from '../schemas';
+import {
+  commitOperationsToBatch,
+  commitOperationToOps,
+} from './fromCommitOperation';
+import { projectBatches } from './project';
+
+const uuid = () => crypto.randomUUID();
+
+describe('commitOperationToOps', () => {
+  test('node.update は content / properties / parentId を最大3つの op に展開する', () => {
+    const nodeId = uuid();
+    const parentId = uuid();
+    const op: CommitOperation = {
+      op: 'node.update',
+      nodeId,
+      content: 'X',
+      properties: { color: 'red' },
+      parentId,
+    };
+    const ops = commitOperationToOps(op);
+    expect(ops.map((o) => o.kind)).toEqual([
+      'node.setContent',
+      'node.setProperties',
+      'node.setParent',
+    ]);
+  });
+
+  test('edge.remove は edge.remove op へ写像する', () => {
+    const edgeId = uuid();
+    expect(commitOperationToOps({ op: 'edge.remove', edgeId })).toEqual([
+      { kind: 'edge.remove', target: edgeId },
+    ]);
+  });
+});
+
+describe('commitOperationsToBatch → projectBatches', () => {
+  test('CommitOperation 列がグラフ状態を正しく導出する (同期語彙の部分集合性)', () => {
+    const a = uuid();
+    const b = uuid();
+    const e = uuid();
+    const ops: CommitOperation[] = [
+      { op: 'node.add', nodeId: a, content: 'A' },
+      { op: 'node.add', nodeId: b, content: 'B' },
+      { op: 'edge.add', edgeId: e, sourceId: a, targetId: b, label: 'rel' },
+      { op: 'node.update', nodeId: a, content: 'A2' },
+    ];
+    const batch = commitOperationsToBatch(ops, {
+      actor: 'did:example:alice',
+      clock: 1,
+      timestamp: Date.now(),
+    });
+    const g = projectBatches([batch]);
+    expect(g.nodes.get(a as never)?.content).toBe('A2');
+    expect(g.edges.get(e as never)?.label).toBe('rel');
+  });
+});

--- a/src/shared/src/events/fromCommitOperation.ts
+++ b/src/shared/src/events/fromCommitOperation.ts
@@ -1,0 +1,102 @@
+/**
+ * CommitOperation → 統一イベント (Op[]) のエンコーダ
+ *
+ * 既存の同期語彙 `CommitOperation` (6 種) が統一語彙の部分集合であることを示す。
+ * 1 つの `node.update` / `edge.update` は複数の Op (setContent + setProperties + setParent)
+ * に展開されうる。
+ */
+
+import type { CommitOperation, EdgeId, NodeId } from '../schemas';
+import {
+  type Actor,
+  type Batch,
+  type BatchId,
+  BatchIdSchema,
+  type Lamport,
+  type Op,
+} from './unified';
+
+export function commitOperationToOps(op: CommitOperation): Op[] {
+  switch (op.op) {
+    case 'node.add':
+      return [
+        {
+          kind: 'node.add',
+          target: op.nodeId as NodeId,
+          content: op.content,
+          ...(op.properties && { properties: op.properties }),
+          ...(op.nodeType && { nodeType: op.nodeType }),
+          ...(op.parentId !== undefined && {
+            parentId: op.parentId as NodeId,
+          }),
+        },
+      ];
+    case 'node.update': {
+      const ops: Op[] = [];
+      if (op.content !== undefined)
+        ops.push({
+          kind: 'node.setContent',
+          target: op.nodeId as NodeId,
+          content: op.content,
+        });
+      if (op.properties !== undefined)
+        ops.push({
+          kind: 'node.setProperties',
+          target: op.nodeId as NodeId,
+          properties: op.properties,
+        });
+      if (op.parentId !== undefined)
+        ops.push({
+          kind: 'node.setParent',
+          target: op.nodeId as NodeId,
+          parentId: op.parentId as NodeId,
+        });
+      return ops;
+    }
+    case 'node.remove':
+      return [{ kind: 'node.remove', target: op.nodeId as NodeId }];
+    case 'edge.add':
+      return [
+        {
+          kind: 'edge.add',
+          target: op.edgeId as EdgeId,
+          source: op.sourceId as NodeId,
+          dest: op.targetId as NodeId,
+          ...(op.label !== undefined && { label: op.label }),
+          ...(op.properties && { properties: op.properties }),
+        },
+      ];
+    case 'edge.update': {
+      const ops: Op[] = [];
+      if (op.label !== undefined)
+        ops.push({
+          kind: 'edge.setLabel',
+          target: op.edgeId as EdgeId,
+          label: op.label,
+        });
+      if (op.properties !== undefined)
+        ops.push({
+          kind: 'edge.setProperties',
+          target: op.edgeId as EdgeId,
+          properties: op.properties,
+        });
+      return ops;
+    }
+    case 'edge.remove':
+      return [{ kind: 'edge.remove', target: op.edgeId as EdgeId }];
+  }
+}
+
+/** CommitOperation[] を 1 つの Batch にまとめる (1 コミット = 1 バッチ相当) */
+export function commitOperationsToBatch(
+  ops: CommitOperation[],
+  meta: { id?: BatchId; actor: Actor; clock: Lamport; timestamp: number },
+): Batch {
+  return {
+    id: meta.id ?? (BatchIdSchema.parse(crypto.randomUUID()) as BatchId),
+    actor: meta.actor,
+    clock: meta.clock,
+    timestamp: meta.timestamp,
+    ops: ops.flatMap(commitOperationToOps),
+  };
+}

--- a/src/shared/src/events/project.test.md
+++ b/src/shared/src/events/project.test.md
@@ -1,0 +1,18 @@
+# project.test.ts — projection のテスト仕様
+
+## 何を
+
+`project.ts` の `projectBatches` (統一イベント → グラフ状態の fold) と `toSheet` を検証する。
+
+## なぜ
+
+projection は step1 §4 の「集約は projection (導出ビュー)」を実現する要。エディタ・エクスポート・拡張エンジンがすべてこの導出結果を読むため、畳み込みの意味論 (LWW・カスケード削除・layout の部分更新) を正確に固定する必要がある。
+
+## どのように
+
+- **状態構築**: node.add / edge.add から nodes / edges マップが構築されることを確認する。
+- **LWW (投入順非依存)**: 同一ノードへの content 変更を、投入順を入れ替えて渡しても clock 昇順で解決され、clock 最大が勝つことを確認する。決定論的なマージの土台。
+- **カスケード削除**: node.remove が接続エッジも削除する (現行 `applyEvent` の NODE_DELETED と同じ挙動) ことを確認する。
+- **layout の部分更新**: 移動 (x/y) と リサイズ (width/height) を別々の setLayout で与えても合成されることを確認する。滑らかな移動・リサイズを独立イベントとして扱うため。
+- **presentation の分離**: presentation op (edge.setStyle 等) は presentation マップに入り、意味的な状態 (edges の properties 等) に影響しないことを確認する (D7: presentation はローカル限定)。
+- **toSheet**: projection が既存の `Sheet` 形式へ変換されることを確認する (現行資産との接続点)。

--- a/src/shared/src/events/project.test.ts
+++ b/src/shared/src/events/project.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  type EdgeId,
+  EdgeIdSchema,
+  type NodeId,
+  NodeIdSchema,
+  type SheetId,
+  SheetIdSchema,
+} from '../schemas';
+import { projectBatches, toSheet } from './project';
+import { type Batch, BatchIdSchema, type Op } from './unified';
+
+const nid = (): NodeId => NodeIdSchema.parse(crypto.randomUUID());
+const eid = (): EdgeId => EdgeIdSchema.parse(crypto.randomUUID());
+
+function batch(clock: number, ops: Op[], timestamp = clock): Batch {
+  return {
+    id: BatchIdSchema.parse(crypto.randomUUID()),
+    actor: 'local',
+    clock,
+    timestamp,
+    ops,
+  };
+}
+
+describe('projectBatches', () => {
+  test('node.add / edge.add で状態を構築する', () => {
+    const a = nid();
+    const b = nid();
+    const e = eid();
+    const g = projectBatches([
+      batch(1, [
+        { kind: 'node.add', target: a, content: 'A' },
+        { kind: 'node.add', target: b, content: 'B' },
+        { kind: 'edge.add', target: e, source: a, dest: b },
+      ]),
+    ]);
+    expect(g.nodes.get(a)?.content).toBe('A');
+    expect(g.edges.get(e)).toMatchObject({ source: a, target: b });
+  });
+
+  test('content は clock 昇順の畳み込みで LWW になる (投入順に依存しない)', () => {
+    const a = nid();
+    const older = batch(1, [
+      { kind: 'node.setContent', target: a, content: 'old' },
+    ]);
+    const newer = batch(2, [
+      { kind: 'node.setContent', target: a, content: 'new' },
+    ]);
+    const seed = batch(0, [{ kind: 'node.add', target: a, content: 'init' }]);
+    // 投入順を入れ替えても clock 順に解決される
+    const g = projectBatches([newer, seed, older]);
+    expect(g.nodes.get(a)?.content).toBe('new');
+  });
+
+  test('node.remove は接続エッジをカスケード削除する', () => {
+    const a = nid();
+    const b = nid();
+    const e = eid();
+    const g = projectBatches([
+      batch(1, [
+        { kind: 'node.add', target: a, content: 'A' },
+        { kind: 'node.add', target: b, content: 'B' },
+        { kind: 'edge.add', target: e, source: a, dest: b },
+      ]),
+      batch(2, [{ kind: 'node.remove', target: a }]),
+    ]);
+    expect(g.nodes.has(a)).toBe(false);
+    expect(g.edges.has(e)).toBe(false);
+  });
+
+  test('node.setLayout は移動 (x/y) と リサイズ (width/height) を部分更新で合成する', () => {
+    const a = nid();
+    const g = projectBatches([
+      batch(1, [{ kind: 'node.add', target: a, content: 'A' }]),
+      batch(2, [{ kind: 'node.setLayout', target: a, x: 10, y: 20 }]),
+      batch(3, [{ kind: 'node.setLayout', target: a, width: 100, height: 50 }]),
+    ]);
+    expect(g.nodeLayouts.get(a)).toMatchObject({
+      x: 10,
+      y: 20,
+      width: 100,
+      height: 50,
+    });
+  });
+
+  test('presentation op は presentation マップに入り、意味的な状態に影響しない', () => {
+    const e = eid();
+    const a = nid();
+    const b = nid();
+    const g = projectBatches([
+      batch(1, [
+        { kind: 'node.add', target: a, content: 'A' },
+        { kind: 'node.add', target: b, content: 'B' },
+        { kind: 'edge.add', target: e, source: a, dest: b },
+        { kind: 'edge.setStyle', target: e, style: { stroke: 'red' } },
+      ]),
+    ]);
+    expect(g.presentation.get(e)).toEqual({ stroke: 'red' });
+    expect(g.edges.get(e)?.properties).toBeUndefined();
+  });
+
+  test('toSheet は projection を Sheet 形式へ変換する', () => {
+    const a = nid();
+    const sheetId: SheetId = SheetIdSchema.parse(crypto.randomUUID());
+    const g = projectBatches([
+      batch(1, [
+        { kind: 'node.add', target: a, content: 'A' },
+        { kind: 'node.setLayout', target: a, x: 1, y: 2 },
+      ]),
+    ]);
+    const sheet = toSheet(g, { id: sheetId, name: 'S' });
+    expect(sheet.name).toBe('S');
+    expect(sheet.nodes).toHaveLength(1);
+    expect(sheet.layouts?.[0]).toMatchObject({ x: 1, y: 2 });
+  });
+});

--- a/src/shared/src/events/project.ts
+++ b/src/shared/src/events/project.ts
@@ -1,0 +1,187 @@
+/**
+ * projection: 統一イベント (Batch[]) → グラフ状態 (導出ビュー)
+ *
+ * step1 §4 の「集約は projection」を実現する fold。現行 `applyEvent` の統一版。
+ * Batch を (clock, timestamp, id) 昇順に整列し、Batch 内の Op を配列順に畳み込む。
+ * → 決定論的な LWW (clock 大が後勝ち) が成立する。
+ */
+
+import type {
+  EdgeId,
+  EdgeLayout,
+  GraphEdge,
+  GraphNode,
+  NodeId,
+  NodeLayout,
+  Sheet,
+  SheetId,
+  Style,
+} from '../schemas';
+import type { Batch, Op } from './unified';
+
+export type ProjectedGraph = {
+  nodes: Map<NodeId, GraphNode>;
+  edges: Map<EdgeId, GraphEdge>;
+  nodeLayouts: Map<NodeId, NodeLayout>;
+  edgeLayouts: Map<EdgeId, EdgeLayout>;
+  /** presentation はローカル限定 (同期しない)。target ごとの style / label offset */
+  presentation: Map<string, Style>;
+};
+
+function emptyGraph(): ProjectedGraph {
+  return {
+    nodes: new Map(),
+    edges: new Map(),
+    nodeLayouts: new Map(),
+    edgeLayouts: new Map(),
+    presentation: new Map(),
+  };
+}
+
+/** Batch を決定論的な順序に整列する: clock → timestamp → id */
+function orderBatches(batches: Batch[]): Batch[] {
+  return [...batches].sort(
+    (a, b) =>
+      a.clock - b.clock ||
+      a.timestamp - b.timestamp ||
+      a.id.localeCompare(b.id),
+  );
+}
+
+export function projectBatches(batches: Batch[]): ProjectedGraph {
+  const g = emptyGraph();
+  for (const batch of orderBatches(batches)) {
+    for (const op of batch.ops) {
+      applyOp(g, op);
+    }
+  }
+  return g;
+}
+
+function applyOp(g: ProjectedGraph, op: Op): void {
+  switch (op.kind) {
+    case 'node.add':
+      g.nodes.set(op.target, {
+        id: op.target,
+        content: op.content,
+        ...(op.properties && { properties: op.properties }),
+        ...(op.nodeType && { nodeType: op.nodeType }),
+        ...(op.parentId !== undefined && { parentId: op.parentId }),
+      });
+      break;
+    case 'node.remove': {
+      g.nodes.delete(op.target);
+      g.nodeLayouts.delete(op.target);
+      // 接続エッジもカスケード削除する (applyEvent NODE_DELETED と同じ挙動)
+      for (const [edgeId, edge] of g.edges) {
+        if (edge.source === op.target || edge.target === op.target) {
+          g.edges.delete(edgeId);
+          g.edgeLayouts.delete(edgeId);
+        }
+      }
+      break;
+    }
+    case 'node.setParent': {
+      const node = g.nodes.get(op.target);
+      if (node) {
+        if (op.parentId === undefined) delete node.parentId;
+        else node.parentId = op.parentId;
+      }
+      break;
+    }
+    case 'edge.add':
+      g.edges.set(op.target, {
+        id: op.target,
+        source: op.source,
+        target: op.dest,
+        ...(op.label !== undefined && { label: op.label }),
+        ...(op.properties && { properties: op.properties }),
+      });
+      break;
+    case 'edge.remove':
+      g.edges.delete(op.target);
+      g.edgeLayouts.delete(op.target);
+      break;
+    case 'edge.reconnect': {
+      const edge = g.edges.get(op.target);
+      if (edge) {
+        edge.source = op.source;
+        edge.target = op.dest;
+      }
+      break;
+    }
+    case 'node.setContent': {
+      const node = g.nodes.get(op.target);
+      if (node) node.content = op.content;
+      break;
+    }
+    case 'node.setProperties': {
+      const node = g.nodes.get(op.target);
+      if (node) node.properties = op.properties;
+      break;
+    }
+    case 'edge.setLabel': {
+      const edge = g.edges.get(op.target);
+      if (edge) edge.label = op.label;
+      break;
+    }
+    case 'edge.setProperties': {
+      const edge = g.edges.get(op.target);
+      if (edge) edge.properties = op.properties;
+      break;
+    }
+    case 'node.setLayout': {
+      // 部分更新: 移動 (x/y) と リサイズ (width/height) を独立に畳み込む
+      const prev = g.nodeLayouts.get(op.target) ?? { nodeId: op.target };
+      g.nodeLayouts.set(op.target, {
+        ...prev,
+        ...(op.x !== undefined && { x: op.x }),
+        ...(op.y !== undefined && { y: op.y }),
+        ...(op.width !== undefined && { width: op.width }),
+        ...(op.height !== undefined && { height: op.height }),
+      });
+      break;
+    }
+    case 'edge.setLayout': {
+      const prev = g.edgeLayouts.get(op.target) ?? { edgeId: op.target };
+      g.edgeLayouts.set(op.target, {
+        ...prev,
+        ...(op.sourceHandle !== undefined && { sourceHandle: op.sourceHandle }),
+        ...(op.targetHandle !== undefined && { targetHandle: op.targetHandle }),
+        ...(op.pathType !== undefined && { pathType: op.pathType }),
+      });
+      break;
+    }
+    case 'node.setStyle':
+    case 'edge.setStyle': {
+      const prev = g.presentation.get(op.target) ?? {};
+      g.presentation.set(op.target, { ...prev, ...op.style });
+      break;
+    }
+    case 'edge.setLabelOffset': {
+      const prev = g.presentation.get(op.target) ?? {};
+      g.presentation.set(op.target, {
+        ...prev,
+        labelOffsetX: op.offsetX,
+        labelOffsetY: op.offsetY,
+      });
+      break;
+    }
+  }
+}
+
+/** projection を既存の `Sheet` 形式へ変換する (エディタ・エクスポート・入出力の受け口) */
+export function toSheet(
+  g: ProjectedGraph,
+  meta: { id: SheetId; name: string; description?: string },
+): Sheet {
+  return {
+    id: meta.id,
+    name: meta.name,
+    ...(meta.description !== undefined && { description: meta.description }),
+    nodes: [...g.nodes.values()],
+    edges: [...g.edges.values()],
+    layouts: [...g.nodeLayouts.values()],
+    edgeLayouts: [...g.edgeLayouts.values()],
+  };
+}

--- a/src/shared/src/events/unified.test.md
+++ b/src/shared/src/events/unified.test.md
@@ -1,0 +1,16 @@
+# unified.test.ts — 統一イベント語彙のテスト仕様
+
+## 何を
+
+`unified.ts` が定義する統一イベント語彙 (Op / Batch / カテゴリ分類 / Lamport clock) の不変条件を検証する。
+
+## なぜ
+
+統一語彙は step1 の正典データモデル (D4) の中核であり、同期対象の振り分け (D7) と undo/redo の単位 (バッチ) を規定する。ここが崩れると projection・マージ・同期すべてが破綻するため、語彙の健全性を単体で固定する。
+
+## どのように
+
+- **OP_CATEGORY 網羅性**: `OpSchema` の全 kind に対しカテゴリが 1 対 1 で定義されていることを検証する。op を追加してカテゴリ付けを忘れると失敗する「番人」テスト。
+- **同期対象の振り分け (D7)**: `isSyncable` が presentation のみ false、structure/content/layout は true を返すことを確認する。
+- **LamportClock**: `tick` の単調増加と、`observe` がリモート時刻に `max + 1` で追随することを確認する (並行編集の順序付けの基礎)。
+- **BatchSchema**: 空 ops の Batch を拒否し、妥当な Batch を受理する (バッチは必ず 1 つ以上の op を持つ)。

--- a/src/shared/src/events/unified.test.ts
+++ b/src/shared/src/events/unified.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  BatchSchema,
+  isSyncable,
+  LamportClock,
+  OP_CATEGORY,
+  OpSchema,
+  opCategory,
+} from './unified';
+
+describe('OP_CATEGORY', () => {
+  test('全ての op kind にカテゴリが割り当てられている (追加漏れ検出)', () => {
+    // OpSchema の各選択肢の kind リテラルを列挙する
+    const kinds = OpSchema.options.map(
+      (opt) => opt.shape.kind.value as keyof typeof OP_CATEGORY,
+    );
+    for (const kind of kinds) {
+      expect(OP_CATEGORY[kind]).toBeDefined();
+    }
+    // 逆に、余分なカテゴリ定義がない
+    expect(Object.keys(OP_CATEGORY).sort()).toEqual([...kinds].sort());
+  });
+
+  test('presentation のみローカル限定、他は同期対象 (D7)', () => {
+    expect(
+      isSyncable({ kind: 'node.setStyle', target: 'x' as never, style: {} }),
+    ).toBe(false);
+    expect(
+      isSyncable({
+        kind: 'node.setLayout',
+        target: 'x' as never,
+        x: 1,
+      }),
+    ).toBe(true);
+    expect(opCategory({ kind: 'node.setLayout', target: 'x' as never })).toBe(
+      'layout',
+    );
+  });
+});
+
+describe('LamportClock', () => {
+  test('tick は単調増加する', () => {
+    const c = new LamportClock();
+    expect(c.tick()).toBe(1);
+    expect(c.tick()).toBe(2);
+  });
+
+  test('observe はリモート時刻に追随する (max + 1)', () => {
+    const c = new LamportClock(3);
+    expect(c.observe(10)).toBe(11);
+    expect(c.tick()).toBe(12);
+    expect(c.observe(5)).toBe(13); // 自身の方が大きい場合も +1
+  });
+});
+
+describe('BatchSchema', () => {
+  test('ops が空の Batch は拒否する', () => {
+    const result = BatchSchema.safeParse({
+      id: crypto.randomUUID(),
+      actor: 'local',
+      clock: 0,
+      timestamp: 0,
+      ops: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('妥当な Batch を受理する', () => {
+    const result = BatchSchema.safeParse({
+      id: crypto.randomUUID(),
+      actor: 'local',
+      clock: 1,
+      timestamp: Date.now(),
+      ops: [{ kind: 'node.add', target: crypto.randomUUID(), content: 'A' }],
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/shared/src/events/unified.ts
+++ b/src/shared/src/events/unified.ts
@@ -1,0 +1,209 @@
+/**
+ * 統一イベント語彙 (step1 Phase 1)
+ *
+ * 現行の `GraphEvent` (client, undo/redo) と `CommitOperation` (ATProto 同期) を
+ * 1 つの語彙へ統合する正典。O3 spike (deepse/spikes/o3-report.md) の Go 判定に基づく。
+ *
+ * モデル: **バッチ**
+ *   - 1 ユーザー操作 = `Op` (atomic 操作) の Batch。Batch が undo/redo の単位。
+ *   - 単一操作は「op 1 件の Batch」として統一的に扱う。
+ *   - 同期・マージの解決単位は Batch 内の各 Op (OR-Set / LWW)。
+ *
+ * カテゴリと同期 (step1 §4, D7):
+ *   - structure / content / layout = 同期対象
+ *   - presentation                 = ローカル限定 (システムがルールで導出、再導出可能)
+ */
+
+import { z } from 'zod';
+import {
+  EdgeIdSchema,
+  EdgePathTypeSchema,
+  NodeIdSchema,
+  StyleSchema,
+} from '../schemas';
+
+// --- メタ ---
+
+/** バッチ識別子 (べき等な適用・重複排除の単位) */
+export const BatchIdSchema = z.string().uuid().brand<'BatchId'>();
+export type BatchId = z.infer<typeof BatchIdSchema>;
+
+/** 操作の主体。DID または未接続時の 'local' */
+export const LOCAL_ACTOR = 'local' as const;
+export type Actor = string;
+
+/** 論理時刻 (Lamport)。LWW の順序付けに使用 */
+export type Lamport = number;
+
+export const EVENT_CATEGORIES = [
+  'structure',
+  'content',
+  'layout',
+  'presentation',
+] as const;
+export type Category = (typeof EVENT_CATEGORIES)[number];
+
+// --- Op: atomic 操作 ---
+
+const NodePropertiesSchema = z.record(z.string(), z.unknown());
+
+export const OpSchema = z.discriminatedUnion('kind', [
+  // structure
+  z.object({
+    kind: z.literal('node.add'),
+    target: NodeIdSchema,
+    content: z.string(),
+    properties: NodePropertiesSchema.optional(),
+    nodeType: z.enum(['group', 'image']).optional(),
+    parentId: NodeIdSchema.optional(),
+  }),
+  z.object({ kind: z.literal('node.remove'), target: NodeIdSchema }),
+  z.object({
+    kind: z.literal('node.setParent'),
+    target: NodeIdSchema,
+    parentId: NodeIdSchema.optional(),
+  }),
+  z.object({
+    kind: z.literal('edge.add'),
+    target: EdgeIdSchema,
+    source: NodeIdSchema,
+    dest: NodeIdSchema,
+    label: z.string().optional(),
+    properties: NodePropertiesSchema.optional(),
+  }),
+  z.object({ kind: z.literal('edge.remove'), target: EdgeIdSchema }),
+  z.object({
+    kind: z.literal('edge.reconnect'),
+    target: EdgeIdSchema,
+    source: NodeIdSchema,
+    dest: NodeIdSchema,
+    sourceHandle: z.string().optional(),
+    targetHandle: z.string().optional(),
+  }),
+  // content
+  z.object({
+    kind: z.literal('node.setContent'),
+    target: NodeIdSchema,
+    content: z.string(),
+  }),
+  z.object({
+    kind: z.literal('node.setProperties'),
+    target: NodeIdSchema,
+    properties: NodePropertiesSchema,
+  }),
+  z.object({
+    kind: z.literal('edge.setLabel'),
+    target: EdgeIdSchema,
+    label: z.string(),
+  }),
+  z.object({
+    kind: z.literal('edge.setProperties'),
+    target: EdgeIdSchema,
+    properties: NodePropertiesSchema,
+  }),
+  // layout
+  z.object({
+    kind: z.literal('node.setLayout'),
+    target: NodeIdSchema,
+    x: z.number().optional(),
+    y: z.number().optional(),
+    width: z.union([z.number(), z.string()]).optional(),
+    height: z.union([z.number(), z.string()]).optional(),
+  }),
+  z.object({
+    kind: z.literal('edge.setLayout'),
+    target: EdgeIdSchema,
+    sourceHandle: z.string().optional(),
+    targetHandle: z.string().optional(),
+    pathType: EdgePathTypeSchema.optional(),
+  }),
+  // presentation (ローカル限定)
+  z.object({
+    kind: z.literal('node.setStyle'),
+    target: NodeIdSchema,
+    style: StyleSchema,
+  }),
+  z.object({
+    kind: z.literal('edge.setStyle'),
+    target: EdgeIdSchema,
+    style: StyleSchema,
+  }),
+  z.object({
+    kind: z.literal('edge.setLabelOffset'),
+    target: EdgeIdSchema,
+    offsetX: z.number(),
+    offsetY: z.number(),
+  }),
+]);
+export type Op = z.infer<typeof OpSchema>;
+export type OpKind = Op['kind'];
+
+/** op の種別 → カテゴリ。同期対象の振り分け (structure/content/layout=同期, presentation=ローカル) に使う */
+export const OP_CATEGORY: Record<OpKind, Category> = {
+  'node.add': 'structure',
+  'node.remove': 'structure',
+  'node.setParent': 'structure',
+  'edge.add': 'structure',
+  'edge.remove': 'structure',
+  'edge.reconnect': 'structure',
+  'node.setContent': 'content',
+  'node.setProperties': 'content',
+  'edge.setLabel': 'content',
+  'edge.setProperties': 'content',
+  'node.setLayout': 'layout',
+  'edge.setLayout': 'layout',
+  'node.setStyle': 'presentation',
+  'edge.setStyle': 'presentation',
+  'edge.setLabelOffset': 'presentation',
+};
+
+export function opCategory(op: Op): Category {
+  return OP_CATEGORY[op.kind];
+}
+
+/** presentation はローカル限定。structure/content/layout は同期対象 (D7) */
+export function isSyncable(op: Op): boolean {
+  return opCategory(op) !== 'presentation';
+}
+
+// --- Batch: undo/redo と同期の運搬単位 ---
+
+export const BatchSchema = z.object({
+  id: BatchIdSchema,
+  actor: z.string(),
+  clock: z.number().int().nonnegative(),
+  timestamp: z.number().int().nonnegative(), // wall clock (表示・tiebreak 用)
+  ops: z.array(OpSchema).min(1),
+});
+export type Batch = z.infer<typeof BatchSchema>;
+
+// --- Lamport clock ---
+
+/**
+ * 論理時刻の発番器。
+ * ローカル操作では tick()、リモート受信では observe(remoteClock) を呼び、
+ * clock = max(local, remote) + 1 を維持する。
+ */
+export class LamportClock {
+  private value: Lamport;
+
+  constructor(initial: Lamport = 0) {
+    this.value = initial;
+  }
+
+  /** 次のローカル論理時刻を発番する */
+  tick(): Lamport {
+    this.value += 1;
+    return this.value;
+  }
+
+  /** リモートの論理時刻を観測し、自身を追随させる (max+1) */
+  observe(remote: Lamport): Lamport {
+    this.value = Math.max(this.value, remote) + 1;
+    return this.value;
+  }
+
+  current(): Lamport {
+    return this.value;
+  }
+}

--- a/src/shared/src/index.ts
+++ b/src/shared/src/index.ts
@@ -1,6 +1,9 @@
 import { z } from 'zod';
 import { GraphFileSchema } from './schemas';
 
+export * from './events/fromCommitOperation';
+export * from './events/project';
+export * from './events/unified';
 export * from './migrations';
 export * from './schemas';
 


### PR DESCRIPTION
## 概要

step1 実装計画の **Phase 1**。`GraphEvent` (client) と `CommitOperation` (ATProto 同期) を **1 つの統一語彙へ収れん**させる正典を追加する。

**非破壊・追加のみ**: 既存語彙の呼び出し箇所は温存。実置換は Phase 2 以降。

## 確定した設計決定

- **バッチモデル**: 1 ユーザー操作 = 基本 op の Batch。undo/redo 単位 = Batch、同期/マージの解決単位 = 個々の Op。
- **論理時刻 = Lamport** (`LamportClock`, `observe = max+1`)。
- **layout を語彙に内包** (D7): `node.setLayout` / `edge.setLayout` を同期対象 op として定義。

## 成果物

| ファイル | 役割 |
|---|---|
| `src/shared/src/events/unified.ts` | 統一語彙 (Op 15種 / Batch / OP_CATEGORY / isSyncable / LamportClock) |
| `src/shared/src/events/project.ts` | `projectBatches` (fold) + `toSheet`。LWW / カスケード削除 / layout 部分更新 / presentation 分離 |
| `src/shared/src/events/fromCommitOperation.ts` | `CommitOperation`(6種) → Op[]。**同期語彙の部分集合性を証明** |
| `src/client/src/events/toUnified.ts` | `GraphEvent`(19種) → Batch。**client 語彙の部分集合性を証明**・複合イベント分解 |

## テスト

- 20 テスト追加 (全 **326 pass**)、typecheck / lint クリーン。各 `.test.md` あり。
- 網羅性の番人: 全 op kind のカテゴリ付け、全 19 GraphEvent 型の分解を強制。

## Phase 2 へ引き継ぐ既知の制約

1. `NODE_PROPERTIES_CHANGED.to` は差分 → 統一 op は置換意味論。capture 時に full properties が必要。
2. `NODE_STYLE_CHANGED` を layout へ正規化。旧発行箇所の整理は Phase 2。
3. 呼び出し箇所の実置換は Phase 2 以降 (本 PR は追加のみ)。
4. add-wins OR-Set の厳密化 (concurrent add/remove) は未実装 (現 projection は clock-LWW)。

## レビュー観点

- 統一語彙 (Op の粒度・カテゴリ分類) が Phase 2 (branchState 載せ替え) の土台として妥当か
- 複合イベントのバッチ分解 (特に group/paste/reparent) の写像が正しいか

🤖 Generated with [Claude Code](https://claude.com/claude-code)