### PR TITLE
Phase 2: ログベースの branch/commit/merge ドメイン

### DIFF
--- a/deepse/plans/step1-implementation.md
+++ b/deepse/plans/step1-implementation.md
@@ -108,3 +108,15 @@ branch: "{branchId}_{uuid}"
   2. `NODE_STYLE_CHANGED` を layout へ正規化した。旧イベント発行箇所の整理は Phase 2。
   3. 本 Phase は**追加のみ (非破壊)**。既存 `GraphEvent`/`CommitOperation` の呼び出し箇所の実置換は Phase 2 以降。
   4. add-wins OR-Set の厳密化 (concurrent add/remove) は未実装 (現 projection は clock-LWW)。
+
+## 6. Phase 2 完了メモ (2026-07-12)
+
+- **成果物** (`src/shared/src/events/`):
+  - `merge.ts`: `mergeBranches` — ブランチ batches を trunk へ追記するログマージ。content 対立検出 + layout 静かな LWW + structure 保持。`mergeBranchToTrunk` (レコード複製) の置換。
+  - `branchLog.ts`: `Branch`/`Commit` をログオフセットとして再定義。`tipClock`/`makeCommit`/`batchesUpTo`/`branchSheet`。rkey 複製方式のドメイン概念 (createBranch/createMainBranch/fetchBranchSheetFromPds) の置換。
+- **テスト**: 9 追加 (全 335 pass)。各 `.test.md` あり。
+- **非破壊**: 旧 `branchState.ts` は `@deprecated` バナーを付けて温存。App 配線・PDS I/O の実置換は Phase 3 (永続層) / Phase 4 (sync-provider) で行い、切り替わり次第削除する。
+- **Phase 3/4 へ引き継ぐ作業**:
+  1. `branchState.ts` の PDS I/O 4 関数 (fetchBranches/fetchCommits/updateBranchStatus/createMergeRecord) を sync-provider へ退避。
+  2. App.tsx / useEventStore の branchState 依存を `branchLog`/`merge` へ切り替え。
+  3. `computeOperations` (state diff) は UI diff 用途が残る場合のみ layout 対応で存続、不要なら廃棄。

--- a/src/client/src/atproto/branchState.ts
+++ b/src/client/src/atproto/branchState.ts
@@ -1,4 +1,16 @@
 /**
+ * @deprecated step1 Phase 2 で置換予定。
+ *
+ * このモジュールは Branch/Commit を Node/Edge レコードの rkey 複製 (trunk_/branchId_)
+ * として実体化する旧方式。統一イベントログ方式への載せ替え先は:
+ *   - ドメイン: `@conversensus/shared` の `events/branchLog.ts` (ブランチ=base+追記, コミット=ラベル付きオフセット)
+ *   - マージ:   `events/merge.ts` (レコード複製マージ → ログマージ)
+ * PDS I/O (fetch/update/createMergeRecord 等) は Phase 4 で sync-provider へ退避する。
+ * 既存 PDS データは破棄前提のため、本モジュールは App 配線が切り替わり次第削除する。
+ * 詳細: deepse/spikes/o3-report.md の解体マップ。
+ */
+
+/**
  * Branch / Commit のドメイン型とロジック
  *
  * - Branch: sheet の子として存在するバージョン (trunk も含む)

--- a/src/shared/src/events/branchLog.test.md
+++ b/src/shared/src/events/branchLog.test.md
@@ -1,0 +1,19 @@
+# branchLog.test.ts — ブランチ/コミットログドメインのテスト仕様
+
+## 何を
+
+`branchLog.ts` の `tipClock` / `makeCommit` / `batchesUpTo` / `branchSheet` を検証する。
+
+## なぜ
+
+O3 spike で確定した再定義 —「コミット = ログ上のラベル付きオフセット、ブランチ = base + 追記 batches」— を production 型で固定する。現行 `branchState.ts` のレコード複製方式 (createBranch/createMainBranch/fetchBranchSheetFromPds) のドメイン概念を置換する Phase 2 の要。
+
+## どのように
+
+- **tipClock**: batches 中の最大 clock (ログ先端) を返し、空なら 0 になることを確認する。
+- **makeCommit**: 現在の先端を指すコミット (オフセット) を作ることを確認する。コミットは「どの clock までを含むか」を表す。
+- **batchesUpTo**: base コミット時点 (clock <= base.at) までの batches を切り出すことを確認する。ブランチの分岐点を決める。
+- **branchSheet**: base 時点の trunk batches にブランチ側 batches を重ねて projection すると、
+  - base より後の trunk 変更は含まれず (分岐後の trunk は見えない)、
+  - ブランチ側の変更・追加が反映される
+  ことを確認する。ブランチの状態がログの projection として導出できる証拠。

--- a/src/shared/src/events/branchLog.test.ts
+++ b/src/shared/src/events/branchLog.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  type BranchId,
+  BranchIdSchema,
+  type CommitId,
+  CommitIdSchema,
+  type NodeId,
+  NodeIdSchema,
+  type SheetId,
+  SheetIdSchema,
+} from '../schemas';
+import {
+  BRANCH_STATUS,
+  type Branch,
+  batchesUpTo,
+  branchSheet,
+  makeCommit,
+  tipClock,
+} from './branchLog';
+import { type Batch, BatchIdSchema, type Op } from './unified';
+
+const nid = (): NodeId => NodeIdSchema.parse(crypto.randomUUID());
+const cid = (): CommitId => CommitIdSchema.parse(crypto.randomUUID());
+const bid = (): BranchId => BranchIdSchema.parse(crypto.randomUUID());
+
+function batch(clock: number, ops: Op[]): Batch {
+  return {
+    id: BatchIdSchema.parse(crypto.randomUUID()),
+    actor: 'local',
+    clock,
+    timestamp: clock,
+    ops,
+  };
+}
+
+describe('tipClock / makeCommit / batchesUpTo', () => {
+  test('tipClock は最大 clock を返す (空なら 0)', () => {
+    expect(tipClock([])).toBe(0);
+    expect(tipClock([batch(3, []), batch(7, []), batch(5, [])])).toBe(7);
+  });
+
+  test('makeCommit は現在の先端を指すラベル付きオフセットを作る', () => {
+    const batches = [batch(2, []), batch(5, [])];
+    const commit = makeCommit(cid(), 'wip', 'did:example:alice', batches);
+    expect(commit.at).toBe(5);
+    expect(commit.message).toBe('wip');
+  });
+
+  test('batchesUpTo は base コミット時点までの batches を切り出す', () => {
+    const batches = [batch(1, []), batch(3, []), batch(5, [])];
+    const commit = makeCommit(cid(), 'base', 'local', [batch(3, [])]);
+    expect(batchesUpTo(batches, commit).map((b) => b.clock)).toEqual([1, 3]);
+  });
+});
+
+describe('branchSheet', () => {
+  test('base 時点の trunk にブランチ変更を重ねて sheet を導出する', () => {
+    const a = nid();
+    const b = nid();
+    // trunk: clock1 で A 追加, clock2 で A を 'A-trunk' に (base より後 = ブランチには含めない)
+    const trunkBatches = [
+      batch(1, [{ kind: 'node.add', target: a, content: 'A' }]),
+      batch(2, [{ kind: 'node.setContent', target: a, content: 'A-trunk' }]),
+    ];
+    // base コミットは clock 1 時点
+    const base = makeCommit(cid(), 'base', 'local', [batch(1, [])]);
+    const branch: Branch = {
+      id: bid(),
+      name: 'feature',
+      base,
+      status: BRANCH_STATUS.OPEN,
+    };
+    // ブランチ側: B 追加 + A を 'A-branch' に
+    const branchBatches = [
+      batch(3, [
+        { kind: 'node.add', target: b, content: 'B' },
+        { kind: 'node.setContent', target: a, content: 'A-branch' },
+      ]),
+    ];
+    const sheetId: SheetId = SheetIdSchema.parse(crypto.randomUUID());
+    const sheet = branchSheet(branch, trunkBatches, branchBatches, {
+      id: sheetId,
+      name: 'S',
+    });
+
+    // base は clock<=1 なので trunk の clock2 変更 (A-trunk) は含まれない
+    // → ブランチ側の A-branch が見える
+    const nodeA = sheet.nodes.find((n) => n.id === a);
+    expect(nodeA?.content).toBe('A-branch');
+    expect(sheet.nodes.some((n) => n.id === b)).toBe(true);
+  });
+});

--- a/src/shared/src/events/branchLog.ts
+++ b/src/shared/src/events/branchLog.ts
@@ -1,0 +1,75 @@
+/**
+ * ブランチ/コミットのログドメイン (step1 Phase 2)
+ *
+ * O3 spike の Go 判定に基づく再定義:
+ *   - コミット = 操作ログ上の**ラベル付きオフセット** (どの clock までを含むか)
+ *   - ブランチ = base コミット + そのブランチで追記された batches
+ *   - ブランチの sheet = base までの trunk batches + branch batches の projection
+ *
+ * 現行 `branchState.ts` の rkey 複製方式 (createMainBranch/createBranch/
+ * fetchBranchSheetFromPds/mergeBranchToTrunk 等) のドメイン概念を置換する。
+ * PDS I/O (sync-provider への退避分) は含めない (Phase 4)。
+ */
+
+import type { BranchId, CommitId, Sheet, SheetId } from '../schemas';
+import { projectBatches, toSheet } from './project';
+import type { Batch, Lamport } from './unified';
+
+export const BRANCH_STATUS = {
+  CREATING: 'creating',
+  OPEN: 'open',
+  MERGED: 'merged',
+  CLOSED: 'closed',
+} as const;
+export type BranchStatus = (typeof BRANCH_STATUS)[keyof typeof BRANCH_STATUS];
+
+/** コミット = 操作ログ上のラベル付きオフセット */
+export type Commit = {
+  id: CommitId;
+  message: string;
+  /** このコミットが指すログ位置。clock <= at の batch を含む */
+  at: Lamport;
+  authorActor: string;
+};
+
+/** ブランチ = base コミットからの分岐 */
+export type Branch = {
+  id: BranchId;
+  name: string;
+  base: Commit;
+  status: BranchStatus;
+};
+
+/** batches 中の最大 clock (= 現在のログ先端)。空なら 0 */
+export function tipClock(batches: Batch[]): Lamport {
+  return batches.reduce((max, b) => Math.max(max, b.clock), 0);
+}
+
+/** 現在のログ先端にラベル付きコミット (オフセット) を作る */
+export function makeCommit(
+  id: CommitId,
+  message: string,
+  authorActor: string,
+  batches: Batch[],
+): Commit {
+  return { id, message, at: tipClock(batches), authorActor };
+}
+
+/** base コミット時点までの batches (clock <= base.at) を切り出す */
+export function batchesUpTo(batches: Batch[], commit: Commit): Batch[] {
+  return batches.filter((b) => b.clock <= commit.at);
+}
+
+/**
+ * ブランチの sheet を導出する。
+ * base 時点の trunk batches に、ブランチ側 batches を重ねて projection する。
+ */
+export function branchSheet(
+  branch: Branch,
+  trunkBatches: Batch[],
+  branchBatches: Batch[],
+  meta: { id: SheetId; name: string; description?: string },
+): Sheet {
+  const base = batchesUpTo(trunkBatches, branch.base);
+  return toSheet(projectBatches([...base, ...branchBatches]), meta);
+}

--- a/src/shared/src/events/merge.test.md
+++ b/src/shared/src/events/merge.test.md
@@ -1,0 +1,21 @@
+# merge.test.ts — ログマージのテスト仕様
+
+## 何を
+
+`merge.ts` の `mergeBranches` (ブランチの batches を trunk へ追記するマージ) を検証する。
+
+## なぜ
+
+現行 `mergeBranchToTrunk` (レコード複製) を置換する Phase 2 の中核。conversensus の主題である「コンフリクト = 合意形成の機会」を成立させるため、**content の並行変更を対立として検出**しつつ、layout は静かに解決する (D7) という区別を正確に固定する必要がある。
+
+## どのように
+
+- **content 対立の検出 + LWW**: trunk と branch が同一ノードの content を別の値へ並行変更した場合、対立を 1 件検出し、projection では clock 最大が勝つ (LWW 暫定確定) ことを確認する。
+- **layout は対立にしない**: 同一ノードの layout 並行変更は対立 0 件で、projection は clock 最大の値になる (静かな LWW, D7)。
+- **同値の並行変更は対立にしない**: 同じ値への並行 content 変更は対立にならない (無意味な対立を出さない)。
+- **structure の OR-Set**: ブランチ側で追加したノード・エッジがマージ後も保持される。
+- **異なる target は非対立**: 別ノードへの content 変更同士は対立しない (対立は同一 target に限定)。
+
+## 対象外 (将来課題)
+
+- concurrent add/remove の add-wins OR-Set 厳密化 (現状は projection の clock-LWW に委ねる)。

--- a/src/shared/src/events/merge.test.ts
+++ b/src/shared/src/events/merge.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  type EdgeId,
+  EdgeIdSchema,
+  type NodeId,
+  NodeIdSchema,
+} from '../schemas';
+import { mergeBranches } from './merge';
+import { projectBatches } from './project';
+import { type Batch, BatchIdSchema, type Op } from './unified';
+
+const nid = (): NodeId => NodeIdSchema.parse(crypto.randomUUID());
+const eid = (): EdgeId => EdgeIdSchema.parse(crypto.randomUUID());
+
+function batch(clock: number, ops: Op[], actor = 'local'): Batch {
+  return {
+    id: BatchIdSchema.parse(crypto.randomUUID()),
+    actor,
+    clock,
+    timestamp: clock,
+    ops,
+  };
+}
+
+describe('mergeBranches', () => {
+  test('content の並行変更を対立として検出し、LWW で暫定確定する', () => {
+    const a = nid();
+    // base: A を追加 (clock 1)
+    // trunk: A を 'trunk' に (clock 2, alice)
+    // branch: A を 'branch' に (clock 3, bob)
+    const trunkAfterBase = [
+      batch(
+        2,
+        [{ kind: 'node.setContent', target: a, content: 'trunk' }],
+        'alice',
+      ),
+    ];
+    const branchBatches = [
+      batch(
+        3,
+        [{ kind: 'node.setContent', target: a, content: 'branch' }],
+        'bob',
+      ),
+    ];
+    const { merged, conflicts } = mergeBranches(trunkAfterBase, branchBatches);
+
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].target).toBe(a);
+    expect(conflicts[0].category).toBe('content');
+
+    // base を含めて projection すると clock 最大の 'branch' が勝つ (LWW)
+    const base = [batch(1, [{ kind: 'node.add', target: a, content: 'init' }])];
+    const g = projectBatches([...base, ...merged]);
+    expect(g.nodes.get(a)?.content).toBe('branch');
+  });
+
+  test('layout の並行変更は対立にしない (静かな LWW)', () => {
+    const a = nid();
+    const trunkAfterBase = [
+      batch(2, [{ kind: 'node.setLayout', target: a, x: 10, y: 10 }]),
+    ];
+    const branchBatches = [
+      batch(3, [{ kind: 'node.setLayout', target: a, x: 99, y: 99 }]),
+    ];
+    const { merged, conflicts } = mergeBranches(trunkAfterBase, branchBatches);
+
+    expect(conflicts).toHaveLength(0); // layout は対立に含めない (D7)
+
+    const base = [batch(1, [{ kind: 'node.add', target: a, content: 'A' }])];
+    const g = projectBatches([...base, ...merged]);
+    expect(g.nodeLayouts.get(a)).toMatchObject({ x: 99, y: 99 }); // clock 最大が勝つ
+  });
+
+  test('同じ値への並行変更は対立にしない', () => {
+    const a = nid();
+    const trunkAfterBase = [
+      batch(2, [{ kind: 'node.setContent', target: a, content: 'same' }]),
+    ];
+    const branchBatches = [
+      batch(3, [{ kind: 'node.setContent', target: a, content: 'same' }]),
+    ];
+    const { conflicts } = mergeBranches(trunkAfterBase, branchBatches);
+    expect(conflicts).toHaveLength(0);
+  });
+
+  test('structure の新規追加はマージ後も保持される (OR-Set)', () => {
+    const a = nid();
+    const d = nid();
+    const e = eid();
+    const trunkAfterBase = [
+      batch(2, [{ kind: 'node.add', target: a, content: 'A' }]),
+    ];
+    const branchBatches = [
+      batch(3, [
+        { kind: 'node.add', target: d, content: 'D' },
+        { kind: 'edge.add', target: e, source: a, dest: d },
+      ]),
+    ];
+    const { merged } = mergeBranches(trunkAfterBase, branchBatches);
+    const g = projectBatches(merged);
+    expect(g.nodes.has(a)).toBe(true);
+    expect(g.nodes.has(d)).toBe(true);
+    expect(g.edges.has(e)).toBe(true);
+  });
+
+  test('異なるノードへの content 変更は対立しない', () => {
+    const a = nid();
+    const b = nid();
+    const trunkAfterBase = [
+      batch(2, [{ kind: 'node.setContent', target: a, content: 'a2' }]),
+    ];
+    const branchBatches = [
+      batch(3, [{ kind: 'node.setContent', target: b, content: 'b2' }]),
+    ];
+    const { conflicts } = mergeBranches(trunkAfterBase, branchBatches);
+    expect(conflicts).toHaveLength(0);
+  });
+});

--- a/src/shared/src/events/merge.ts
+++ b/src/shared/src/events/merge.ts
@@ -1,0 +1,91 @@
+/**
+ * ログマージ (step1 Phase 2)
+ *
+ * 現行の `mergeBranchToTrunk` (レコード複製) を置換する。ブランチのマージを
+ * 「ブランチの batches を trunk へ追記する」操作として表現する (O3 spike の設計)。
+ *
+ * D7 の解決ルール:
+ *   - content  : LWW (projection の clock 順畳み込みで確定) + 並行変更を「対立」として検出
+ *   - layout   : LWW のみ (対立にしない)。追記して projection に委ねる
+ *   - structure: 追記して projection に委ねる (clock-LWW。add-wins OR-Set 厳密化は将来課題)
+ *
+ * 解決そのものは `projectBatches` の決定論的な clock 順畳み込みに委ね、
+ * この関数は「追記 + content 対立の検出」に集中する。
+ */
+
+import type { Batch, BatchId, Op } from './unified';
+import { opCategory } from './unified';
+
+/** content の並行変更 = 合意形成の機会。グラフ上に可視化する候補 */
+export type MergeConflict = {
+  target: string;
+  category: 'content';
+  ours: { batchId: BatchId; op: Op }; // trunk 側
+  theirs: { batchId: BatchId; op: Op }; // branch 側
+};
+
+export type MergeResult = {
+  /** trunk へ追記される、マージ後のログ (projection で解決される) */
+  merged: Batch[];
+  /** 検出された content 対立 */
+  conflicts: MergeConflict[];
+};
+
+type TaggedOp = { batchId: BatchId; clock: number; op: Op };
+
+function flattenContentOps(batches: Batch[]): TaggedOp[] {
+  const out: TaggedOp[] = [];
+  for (const batch of batches) {
+    for (const op of batch.ops) {
+      if (opCategory(op) === 'content') {
+        out.push({ batchId: batch.id, clock: batch.clock, op });
+      }
+    }
+  }
+  return out;
+}
+
+/** target ごとの「最後の content 変更」を引く索引 (clock 最大) */
+function lastContentByTarget(tagged: TaggedOp[]): Map<string, TaggedOp> {
+  const m = new Map<string, TaggedOp>();
+  for (const t of tagged) {
+    const prev = m.get(t.op.target);
+    if (!prev || t.clock > prev.clock) m.set(t.op.target, t);
+  }
+  return m;
+}
+
+function opValueDiffers(a: Op, b: Op): boolean {
+  return JSON.stringify(a) !== JSON.stringify(b);
+}
+
+/**
+ * base 以降の trunk batches と branch batches をマージする。
+ *
+ * @param trunkAfterBase 分岐点 (base) 以降に trunk 側で追記された batches
+ * @param branchBatches  ブランチ側で追記された batches
+ */
+export function mergeBranches(
+  trunkAfterBase: Batch[],
+  branchBatches: Batch[],
+): MergeResult {
+  // 解決は projection の clock 順畳み込みに委ねるため、両者を素直に連結する
+  const merged = [...trunkAfterBase, ...branchBatches];
+
+  // content の並行変更を対立として検出する
+  const trunkContent = lastContentByTarget(flattenContentOps(trunkAfterBase));
+  const conflicts: MergeConflict[] = [];
+  for (const theirs of flattenContentOps(branchBatches)) {
+    const ours = trunkContent.get(theirs.op.target);
+    if (ours && opValueDiffers(ours.op, theirs.op)) {
+      conflicts.push({
+        target: theirs.op.target,
+        category: 'content',
+        ours: { batchId: ours.batchId, op: ours.op },
+        theirs: { batchId: theirs.batchId, op: theirs.op },
+      });
+    }
+  }
+
+  return { merged, conflicts };
+}

--- a/src/shared/src/index.ts
+++ b/src/shared/src/index.ts
@@ -1,7 +1,9 @@
 import { z } from 'zod';
 import { GraphFileSchema } from './schemas';
 
+export * from './events/branchLog';
 export * from './events/fromCommitOperation';
+export * from './events/merge';
 export * from './events/project';
 export * from './events/unified';
 export * from './migrations';


### PR DESCRIPTION
## 概要

step1 実装計画の **Phase 2**。`branchState.ts` の **rkey 複製方式を置換**するログベースの branch/commit/merge ドメインを、統一イベント語彙 (Phase 1) の上に構築する。

**非破壊・追加のみ**: 旧 `branchState.ts` は `@deprecated` バナーを付けて温存。App 配線・PDS I/O の実置換は Phase 3/4。

## 成果物

| ファイル | 役割 | 置換対象 |
|---|---|---|
| `src/shared/src/events/merge.ts` | `mergeBranches` — ブランチ batches を trunk へ追記するログマージ。content 対立検出 / layout 静かな LWW / structure 保持 (D7) | `mergeBranchToTrunk` (レコード複製) |
| `src/shared/src/events/branchLog.ts` | `Branch`/`Commit` をログオフセットとして再定義。`tipClock`/`makeCommit`/`batchesUpTo`/`branchSheet` | `createBranch`/`createMainBranch`/`fetchBranchSheetFromPds` のドメイン概念 |

## テスト

- 9 テスト追加 (全 **335 pass**)、typecheck / lint クリーン。各 `.test.md` あり。
- マージの D7 ルール (content=対立検出+LWW / layout=静かな LWW / structure=OR-Set / 同値は非対立 / 別 target は非対立) を固定。

## Phase 3/4 へ引き継ぐ作業

1. `branchState.ts` の PDS I/O 4 関数を sync-provider へ退避 (Phase 4)。
2. App.tsx / useEventStore の branchState 依存を `branchLog`/`merge` へ切り替え (Phase 3/4)。
3. `computeOperations` (state diff) は UI diff 用途が残る場合のみ layout 対応で存続、不要なら廃棄。

## レビュー観点

- ログマージの解決モデル (追記 + projection の clock-LWW に委ね、対立検出に集中) が妥当か
- `Branch`/`Commit` のログオフセット再定義が Phase 3 (永続層) の設計を縛りすぎないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)