### PR TITLE
Phase 3: SQLite ベースのローカル永続層 (操作ログ + projection)

### DIFF
--- a/deepse/plans/step1-implementation.md
+++ b/deepse/plans/step1-implementation.md
@@ -91,7 +91,7 @@ branch: "{branchId}_{uuid}"
 | ID | 未決 | 決定タイミング |
 |---|---|---|
 | ~~論理時刻の実体~~ | **確定: Lamport** (`LamportClock`, observe=max+1)。Phase 1 で実装 | ✅ Phase 1 |
-| O1 ストレージ実体 | JSON / SQLite / IndexedDB | Phase 3 冒頭。O2 (配布形態) と連動 |
+| ~~O1 ストレージ実体~~ | **確定: SQLite (`bun:sqlite`)**。append-only な batches テーブルへ追記し、projection で導出。B2 (ローカル Hono デーモン) 常駐からの並行アクセス・トランザクション・耐久性で採択。組み込みのため依存追加なし | ✅ Phase 3 |
 | ~~複合イベントの正規化~~ | **確定: バッチ** (1 操作 = 基本 op のバッチ, undo 単位 = バッチ, 解決単位 = op) | ✅ Phase 1 |
 
 ## 5. Phase 1 完了メモ (2026-07-12)
@@ -120,3 +120,18 @@ branch: "{branchId}_{uuid}"
   1. `branchState.ts` の PDS I/O 4 関数 (fetchBranches/fetchCommits/updateBranchStatus/createMergeRecord) を sync-provider へ退避。
   2. App.tsx / useEventStore の branchState 依存を `branchLog`/`merge` へ切り替え。
   3. `computeOperations` (state diff) は UI diff 用途が残る場合のみ layout 対応で存続、不要なら廃棄。
+
+## 7. Phase 3 完了メモ (2026-07-13)
+
+- **O1 確定: SQLite (`bun:sqlite`)**。§4 の表を参照。append-only な batches テーブルへ追記し projection で導出する。組み込みのため依存追加なし。
+- **成果物** (`src/server/src/eventStore.ts`):
+  - `EventStore` — 操作ログ永続ストア。1 インスタンス = 1 DB、ファイルごとに `file_id` で仕切る。
+  - スキーマ: `batches`(seq PK / file_id / batch_id / actor / clock / timestamp / ops_json、`UNIQUE(file_id, batch_id)`) + `commits`(ラベル付きオフセット)。読み出し順のため `(file_id, clock, timestamp, batch_id)` にインデックス。WAL 有効。
+  - API: `appendBatch` (INSERT OR IGNORE でべき等) / `appendBatches` (トランザクション) / `getBatches` (clock 昇順) / `projectSheet` (projectBatches → toSheet) / `saveCommit` / `getCommits` / `close`。
+  - 永続化境界の不変条件は「空 ops の Batch を弾く」の最小限。UUID フォーマット検証は外部 API 境界 (HTTP) の責務 (CLAUDE.md)。
+- **テスト**: 12 追加 (全 347 pass)。`.test.md` あり。インメモリ (`:memory:`) で DB を分離。
+- **非破壊**: 旧 `storage.ts` (GraphFile を JSON スナップショット保存) は温存。HTTP API を EventStore へ載せ替える配線は Phase 4 (sync-provider) と併せて行う。
+- **Phase 4 へ引き継ぐ作業**:
+  1. HTTP API (`index.ts`) の `/files` 系を EventStore へ載せ替え (現状は `storage.ts` の全体スナップショット保存)。載せ替え後に `storage.ts` を廃棄。
+  2. Branch (base コミット + 分岐) の永続化。現状 EventStore は batches / commits まで。branches テーブルは sync-provider の分岐管理と併せて設計する。
+  3. Lamport clock の永続化・復元 (再起動後に max(clock)+1 から再開する配線)。

--- a/src/server/src/eventStore.test.md
+++ b/src/server/src/eventStore.test.md
@@ -1,0 +1,38 @@
+# eventStore テスト仕様
+
+## 何を
+
+`EventStore` (step1 Phase 3 のローカル永続層) をテストする。SQLite (`bun:sqlite`) を
+インメモリ (`:memory:`) で起動し、操作ログ (batches) の追記・取得・projection と、
+コミット (ラベル付きオフセット) の保存・取得を検証する。
+
+## なぜ
+
+Phase 3 の永続モデルは「append-only な操作ログ + projection」。保存の正しさは
+次の3点に依存し、いずれも回帰すると静かにデータを壊すため単体で固定する:
+
+1. **べき等な追記**: 同期・再送で同じ Batch が二重適用されうる。`(file_id, batch_id)`
+   の一意制約で重複を無視できないと、ログが膨れ projection が壊れる。
+2. **決定論的な順序**: projection は clock 順の畳み込みに依存する。追記順に関わらず
+   clock 昇順で読み返せることを保証する。
+3. **ファイル境界の分離**: 複数グラフを 1 DB に同居させるため、file_id で batches /
+   commits が確実に仕切られること。
+
+永続化の境界でバリデーション (壊れた Batch を弾く) するのも、ログに不正データを
+残さないための防御であり、テストで固定する。
+
+## どのように
+
+- **appendBatch / getBatches**:
+  - 追記した Batch をそのまま読み返せる (往復)。
+  - 同一 batch_id の再追記は `false` を返し重複しない (べき等)。
+  - file_id が異なれば同一 batch_id でも共存する (境界分離)。
+  - 追記順が逆でも clock 昇順で返る (決定論的順序)。
+  - ops 空の壊れた Batch は `BatchSchema` 検証で追記を拒否する。
+- **appendBatches**: 一括追記でトランザクション適用し、新規に入った件数のみを返す
+  (一部重複時は新規分のみカウント)。
+- **projectSheet**: 操作ログを projection して Sheet を導出する。node.add → node.setContent
+  で LWW の後勝ちが反映されること、空ログでは空 Sheet になること。
+- **saveCommit / getCommits**: at 昇順で読み返す、同一 id は上書き、file_id で分離。
+
+テストは `beforeEach` で毎回新しいインメモリ DB を生成し、テスト間の状態を分離する。

--- a/src/server/src/eventStore.test.ts
+++ b/src/server/src/eventStore.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import type {
+  Batch,
+  Commit,
+  CommitId,
+  FileId,
+  NodeId,
+  SheetId,
+} from '@conversensus/shared';
+import { EventStore, IN_MEMORY } from './eventStore';
+
+const FILE = 'file-1' as FileId;
+const SHEET_META = { id: 'sheet-1' as SheetId, name: 'Sheet 1' };
+
+let store: EventStore;
+
+beforeEach(() => {
+  store = new EventStore(IN_MEMORY);
+});
+
+/** node.add 1 件だけの Batch を作るヘルパ */
+const addNode = (
+  id: string,
+  node: string,
+  content: string,
+  clock: number,
+  timestamp = clock,
+): Batch => ({
+  id: id as Batch['id'],
+  actor: 'local',
+  clock,
+  timestamp,
+  ops: [{ kind: 'node.add', target: node as NodeId, content }],
+});
+
+describe('EventStore', () => {
+  describe('appendBatch / getBatches', () => {
+    it('追記した Batch を読み返せる', () => {
+      const batch = addNode('b1', 'n1', 'ノード1', 1);
+      expect(store.appendBatch(FILE, batch)).toBe(true);
+      expect(store.getBatches(FILE)).toEqual([batch]);
+    });
+
+    it('同一 batch_id の再追記はべき等 (false を返し重複しない)', () => {
+      const batch = addNode('b1', 'n1', 'ノード1', 1);
+      expect(store.appendBatch(FILE, batch)).toBe(true);
+      expect(store.appendBatch(FILE, batch)).toBe(false);
+      expect(store.getBatches(FILE)).toHaveLength(1);
+    });
+
+    it('file_id が異なれば同じ batch_id でも共存する', () => {
+      const other = 'file-2' as FileId;
+      store.appendBatch(FILE, addNode('b1', 'n1', 'A', 1));
+      store.appendBatch(other, addNode('b1', 'n1', 'B', 1));
+      expect(store.getBatches(FILE)).toHaveLength(1);
+      expect(store.getBatches(other)).toHaveLength(1);
+    });
+
+    it('clock 昇順で返す (追記順が逆でも)', () => {
+      store.appendBatch(FILE, addNode('b2', 'n2', 'B', 2));
+      store.appendBatch(FILE, addNode('b1', 'n1', 'A', 1));
+      expect(store.getBatches(FILE).map((b) => b.id)).toEqual(['b1', 'b2']);
+    });
+
+    it('壊れた Batch (ops 空) は追記を拒否する', () => {
+      const broken = { ...addNode('b1', 'n1', 'A', 1), ops: [] } as Batch;
+      expect(() => store.appendBatch(FILE, broken)).toThrow();
+      expect(store.getBatches(FILE)).toHaveLength(0);
+    });
+  });
+
+  describe('appendBatches', () => {
+    it('複数 Batch を一括追記し、新規件数を返す', () => {
+      const inserted = store.appendBatches(FILE, [
+        addNode('b1', 'n1', 'A', 1),
+        addNode('b2', 'n2', 'B', 2),
+      ]);
+      expect(inserted).toBe(2);
+      expect(store.getBatches(FILE)).toHaveLength(2);
+    });
+
+    it('一部が重複していれば新規分のみカウントする', () => {
+      store.appendBatch(FILE, addNode('b1', 'n1', 'A', 1));
+      const inserted = store.appendBatches(FILE, [
+        addNode('b1', 'n1', 'A', 1),
+        addNode('b2', 'n2', 'B', 2),
+      ]);
+      expect(inserted).toBe(1);
+      expect(store.getBatches(FILE)).toHaveLength(2);
+    });
+  });
+
+  describe('projectSheet', () => {
+    it('操作ログを projection して Sheet を導出する', () => {
+      store.appendBatch(FILE, addNode('b1', 'n1', 'ノード1', 1));
+      store.appendBatch(FILE, {
+        id: 'b2' as Batch['id'],
+        actor: 'local',
+        clock: 2,
+        timestamp: 2,
+        ops: [
+          { kind: 'node.setContent', target: 'n1' as NodeId, content: '改' },
+        ],
+      });
+      const sheet = store.projectSheet(FILE, SHEET_META);
+      expect(sheet.id).toBe(SHEET_META.id);
+      expect(sheet.nodes).toHaveLength(1);
+      // LWW: 後勝ちで content が更新されている
+      expect(sheet.nodes[0]?.content).toBe('改');
+    });
+
+    it('空ログでは空の Sheet を返す', () => {
+      const sheet = store.projectSheet(FILE, SHEET_META);
+      expect(sheet.nodes).toEqual([]);
+      expect(sheet.edges).toEqual([]);
+    });
+  });
+
+  describe('saveCommit / getCommits', () => {
+    const commit = (id: string, at: number): Commit => ({
+      id: id as CommitId,
+      message: `commit ${id}`,
+      at,
+      authorActor: 'local',
+    });
+
+    it('保存したコミットを at 昇順で読み返せる', () => {
+      store.saveCommit(FILE, commit('c2', 5));
+      store.saveCommit(FILE, commit('c1', 2));
+      expect(store.getCommits(FILE).map((c) => c.id)).toEqual(['c1', 'c2']);
+    });
+
+    it('同一 id は上書きする', () => {
+      store.saveCommit(FILE, commit('c1', 2));
+      store.saveCommit(FILE, { ...commit('c1', 9), message: '更新' });
+      const commits = store.getCommits(FILE);
+      expect(commits).toHaveLength(1);
+      expect(commits[0]?.at).toBe(9);
+      expect(commits[0]?.message).toBe('更新');
+    });
+
+    it('ファイルが異なるコミットは混ざらない', () => {
+      const other = 'file-2' as FileId;
+      store.saveCommit(FILE, commit('c1', 2));
+      store.saveCommit(other, commit('c2', 2));
+      expect(store.getCommits(FILE).map((c) => c.id)).toEqual(['c1']);
+      expect(store.getCommits(other).map((c) => c.id)).toEqual(['c2']);
+    });
+  });
+});

--- a/src/server/src/eventStore.ts
+++ b/src/server/src/eventStore.ts
@@ -1,0 +1,201 @@
+/**
+ * ローカル永続層: 操作ログ (batches) + projection (step1 Phase 3)
+ *
+ * O1 の確定 (SQLite / `bun:sqlite`) に基づく永続層。
+ * 保存モデルは「append-only な操作ログ + projection」:
+ *   - batches テーブルへ Batch を追記するのみ (更新・削除しない)。
+ *   - グラフ状態 (Sheet) は保存せず、batches の projection で導出する。
+ *   - commits はログ上の**ラベル付きオフセット** (branchLog の `Commit`) を保持する。
+ *
+ * 現行 `storage.ts` (GraphFile を JSON スナップショットで丸ごと保存) の置換候補。
+ * 非破壊: 本 Phase では EventStore を追加するのみで、HTTP API の載せ替えは Phase 4 以降。
+ */
+
+import { Database } from 'bun:sqlite';
+import {
+  type Batch,
+  type Commit,
+  type FileId,
+  projectBatches,
+  type Sheet,
+  type SheetId,
+  toSheet,
+} from '@conversensus/shared';
+
+/** インメモリ DB のパス指定 (テスト用) */
+export const IN_MEMORY = ':memory:';
+
+/** batches の 1 行 (ops は JSON 文字列で保持する) */
+type BatchRow = {
+  batch_id: string;
+  actor: string;
+  clock: number;
+  timestamp: number;
+  ops_json: string;
+};
+
+/** commits の 1 行 */
+type CommitRow = {
+  id: string;
+  message: string;
+  at: number;
+  author_actor: string;
+};
+
+const SCHEMA = `
+CREATE TABLE IF NOT EXISTS batches (
+  seq        INTEGER PRIMARY KEY AUTOINCREMENT,
+  file_id    TEXT    NOT NULL,
+  batch_id   TEXT    NOT NULL,
+  actor      TEXT    NOT NULL,
+  clock      INTEGER NOT NULL,
+  timestamp  INTEGER NOT NULL,
+  ops_json   TEXT    NOT NULL,
+  UNIQUE(file_id, batch_id)
+);
+CREATE INDEX IF NOT EXISTS idx_batches_file_order
+  ON batches (file_id, clock, timestamp, batch_id);
+
+CREATE TABLE IF NOT EXISTS commits (
+  id           TEXT    PRIMARY KEY,
+  file_id      TEXT    NOT NULL,
+  message      TEXT    NOT NULL,
+  at           INTEGER NOT NULL,
+  author_actor TEXT    NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_commits_file ON commits (file_id);
+`;
+
+/**
+ * 操作ログの永続ストア。1 インスタンス = 1 データベース。
+ * ファイル (グラフ) ごとに file_id で batches / commits を仕切る。
+ */
+export class EventStore {
+  private readonly db: Database;
+
+  /** @param path DB ファイルパス。テストでは `IN_MEMORY` を渡す */
+  constructor(path: string) {
+    this.db = new Database(path);
+    // WAL: デーモン常駐からの並行アクセスで読み書きの競合を緩和する
+    this.db.exec('PRAGMA journal_mode = WAL');
+    this.db.exec('PRAGMA foreign_keys = ON');
+    this.db.run(SCHEMA);
+  }
+
+  /**
+   * Batch を操作ログへ追記する。
+   * (file_id, batch_id) が既存なら何もしない (べき等: 同一 Batch の重複適用を無視)。
+   * @returns 新規に追記されたら true、重複で無視されたら false
+   */
+  appendBatch(fileId: FileId, batch: Batch): boolean {
+    // 永続化の最小不変条件: 空 ops の Batch (no-op 行) をログに残さない。
+    // UUID フォーマット等の検証は外部 API 境界 (HTTP) の責務 (CLAUDE.md)。
+    if (batch.ops.length === 0) {
+      throw new Error('Cannot append a batch with empty ops');
+    }
+    const result = this.db
+      .query(
+        `INSERT OR IGNORE INTO batches
+           (file_id, batch_id, actor, clock, timestamp, ops_json)
+         VALUES ($file, $id, $actor, $clock, $ts, $ops)`,
+      )
+      .run({
+        $file: fileId,
+        $id: batch.id,
+        $actor: batch.actor,
+        $clock: batch.clock,
+        $ts: batch.timestamp,
+        $ops: JSON.stringify(batch.ops),
+      });
+    return result.changes > 0;
+  }
+
+  /** 複数 Batch を 1 トランザクションで追記する。@returns 新規追記された件数 */
+  appendBatches(fileId: FileId, batches: Batch[]): number {
+    const tx = this.db.transaction((items: Batch[]) => {
+      let inserted = 0;
+      for (const batch of items) {
+        if (this.appendBatch(fileId, batch)) inserted += 1;
+      }
+      return inserted;
+    });
+    return tx(batches);
+  }
+
+  /**
+   * ファイルの全 Batch を取得する。
+   * 追記順を安定させるため (clock, timestamp, batch_id) 昇順で返すが、
+   * projection は決定論のため内部で再整列する (projectBatches)。
+   */
+  getBatches(fileId: FileId): Batch[] {
+    const rows = this.db
+      .query<BatchRow, string>(
+        `SELECT batch_id, actor, clock, timestamp, ops_json
+           FROM batches
+          WHERE file_id = ?
+          ORDER BY clock, timestamp, batch_id`,
+      )
+      .all(fileId);
+    return rows.map((row) => rowToBatch(row));
+  }
+
+  /** ファイルの操作ログを projection し、Sheet として導出する */
+  projectSheet(
+    fileId: FileId,
+    meta: { id: SheetId; name: string; description?: string },
+  ): Sheet {
+    return toSheet(projectBatches(this.getBatches(fileId)), meta);
+  }
+
+  /** コミット (ラベル付きオフセット) を保存する。同一 id は上書きする */
+  saveCommit(fileId: FileId, commit: Commit): void {
+    this.db
+      .query(
+        `INSERT OR REPLACE INTO commits (id, file_id, message, at, author_actor)
+         VALUES ($id, $file, $msg, $at, $author)`,
+      )
+      .run({
+        $id: commit.id,
+        $file: fileId,
+        $msg: commit.message,
+        $at: commit.at,
+        $author: commit.authorActor,
+      });
+  }
+
+  /** ファイルのコミット一覧を、指すオフセット (at) 昇順で取得する */
+  getCommits(fileId: FileId): Commit[] {
+    const rows = this.db
+      .query<CommitRow, string>(
+        `SELECT id, message, at, author_actor
+           FROM commits
+          WHERE file_id = ?
+          ORDER BY at, id`,
+      )
+      .all(fileId);
+    return rows.map((row) => rowToCommit(row));
+  }
+
+  close(): void {
+    this.db.close();
+  }
+}
+
+function rowToBatch(row: BatchRow): Batch {
+  return {
+    id: row.batch_id as Batch['id'],
+    actor: row.actor,
+    clock: row.clock,
+    timestamp: row.timestamp,
+    ops: JSON.parse(row.ops_json) as Batch['ops'],
+  };
+}
+
+function rowToCommit(row: CommitRow): Commit {
+  return {
+    id: row.id as Commit['id'],
+    message: row.message,
+    at: row.at,
+    authorActor: row.author_actor,
+  };
+}


### PR DESCRIPTION
## 概要

step1 実装計画の **Phase 3: ローカル永続層**。未決だった **O1(ストレージ実体)を SQLite (`bun:sqlite`) に確定**し、「操作ログ(append-only)+ projection」の永続層を実装した。配布形態 O2 = B2(ローカル Hono デーモン + ブラウザ)常駐からの並行アクセス・トランザクション・耐久性で採択。組み込みのため依存追加なし。

## 変更点

- **`src/server/src/eventStore.ts`** — 操作ログ永続ストア `EventStore`
  - スキーマ: `batches`(seq PK / file_id / batch_id / actor / clock / timestamp / ops_json、`UNIQUE(file_id, batch_id)`)+ `commits`(ラベル付きオフセット)。読み出し順に `(file_id, clock, timestamp, batch_id)` インデックス。WAL 有効。
  - API: `appendBatch`(INSERT OR IGNORE でべき等)/ `appendBatches`(トランザクション)/ `getBatches`(clock 昇順)/ `projectSheet`(projectBatches → toSheet)/ `saveCommit` / `getCommits` / `close`
  - 永続化境界の不変条件は「空 ops の Batch を弾く」の最小限。UUID フォーマット検証は外部 API 境界(HTTP)の責務として分離(CLAUDE.md)。
- **`deepse/plans/step1-implementation.md`** — O1 決定を §4 に記録、Phase 3 完了メモ(§7)を追記。

## 非破壊

旧 `storage.ts`(GraphFile を JSON スナップショット保存)は温存。HTTP API の EventStore への載せ替えは Phase 4(sync-provider)と併せて行い、切り替わり次第 `storage.ts` を廃棄する。

## Phase 4 へ引き継ぐ作業

1. HTTP API(`index.ts`)の `/files` 系を EventStore へ載せ替え。載せ替え後に `storage.ts` を廃棄。
2. Branch(base コミット + 分岐)の永続化(branches テーブル)。現状は batches / commits まで。
3. Lamport clock の永続化・復元(再起動後に max(clock)+1 から再開する配線)。

## テスト

- `eventStore.test.ts` を 12 ケース追加(べき等追記 / 決定論的順序 / ファイル境界分離 / projection LWW / commit 保存)。`eventStore.test.md` にテスト仕様。
- 全 **347 pass** / typecheck 0 / lint clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)