### PR TITLE
Phase 4a: SyncProvider 境界 + NullSyncProvider

### DIFF
--- a/deepse/plans/step1-implementation.md
+++ b/deepse/plans/step1-implementation.md
@@ -135,3 +135,25 @@ branch: "{branchId}_{uuid}"
   1. HTTP API (`index.ts`) の `/files` 系を EventStore へ載せ替え (現状は `storage.ts` の全体スナップショット保存)。載せ替え後に `storage.ts` を廃棄。
   2. Branch (base コミット + 分岐) の永続化。現状 EventStore は batches / commits まで。branches テーブルは sync-provider の分岐管理と併せて設計する。
   3. Lamport clock の永続化・復元 (再起動後に max(clock)+1 から再開する配線)。
+
+## 8. Phase 4 (sync-provider) のサブフェーズ分割
+
+Phase 4 (§9-3 / architecture §6) は atproto 配下 ~3458 行の再編 + 外部 I/O を伴い 1 PR に大きすぎるため、非破壊・追加優先で以下に分割する:
+
+| スライス | 内容 | 状態 |
+|---|---|---|
+| **4a** | `SyncProvider` 境界 (push/pull/subscribe) + `NullSyncProvider` (完全ローカル) | ✅ 実装済 (下記メモ) |
+| **4b** | outbox + オフライン分岐 (オフライン時 ops を積み復帰時 flush) | 未着手 |
+| **4c** | ATProto を provider 実装へ整理 (collections/sync/mapper/branchState/poller を `AtprotoSyncProvider` 内部へ封じ込め) | 未着手 |
+| **4d** | 構造改修: 全件 list の解消 (rkey/コレクション範囲取得, R3) / polling → Jetstream / cidCache 永続化 | 未着手 |
+| (併走) | Phase 3 引き継ぎ: HTTP API の EventStore 載せ替え / storage.ts 廃棄 / Lamport clock 永続化 | 未着手 |
+
+### Phase 4a 完了メモ (2026-07-13)
+
+- **成果物** (`src/client/src/sync/`):
+  - `syncProvider.ts`: `SyncProvider` インターフェース (`push(batches)` / `pull(since)` / `subscribe(onRemote)`) + `Cursor` (不透明・provider 定義) / `INITIAL_CURSOR` / `PullResult` (cursor-pagination) / `Unsubscribe` / `OnRemote` 型。
+  - `nullSyncProvider.ts`: `NullSyncProvider` — 完全ローカル (未ログイン・オフライン運用) の既定 provider。push=no-op / pull=空+初期カーソル / subscribe=非配信。外の層が「provider は常に存在する」前提で書けるようにし、ATProto 有無の分岐を消す。
+  - `index.ts`: バレル。
+- **運搬単位は `Batch`** (統一語彙、Phase 1)。architecture §6 の擬似コードは旧 `GraphEvent[]` だが正典一本化に伴い `Batch[]` へ更新。
+- **テスト**: 4 追加 (全 351 pass)。`.test.md` あり。境界の型定義はロジック無しのためテスト対象外、振る舞いを持つ `NullSyncProvider` を固定。
+- **非破壊**: 既存 atproto コードは未変更。provider への封じ込め (4c) と外の層の配線切替は後続スライス。

--- a/src/client/src/sync/index.ts
+++ b/src/client/src/sync/index.ts
@@ -1,0 +1,9 @@
+export { NullSyncProvider } from './nullSyncProvider';
+export {
+  type Cursor,
+  INITIAL_CURSOR,
+  type OnRemote,
+  type PullResult,
+  type SyncProvider,
+  type Unsubscribe,
+} from './syncProvider';

--- a/src/client/src/sync/nullSyncProvider.test.md
+++ b/src/client/src/sync/nullSyncProvider.test.md
@@ -1,0 +1,23 @@
+# nullSyncProvider テスト仕様
+
+## 何を
+
+`NullSyncProvider` (step1 Phase 4a、完全ローカルの `SyncProvider` 実装) をテストする。
+`push` / `pull` / `subscribe` の 3 メソッドが「同期しない」契約どおりに振る舞うことを検証する。
+
+## なぜ
+
+`NullSyncProvider` は「provider が常に存在する」前提を成立させるための既定実装
+(architecture §6 の "null (完全ローカル)")。外の層は ATProto の有無で分岐せず、
+常に `SyncProvider` インターフェースだけに依存できる — その保証がこの provider の
+契約であり、回帰すると未ログイン/オフライン構成が壊れる。
+
+`SyncProvider` 境界そのもの (interface / Cursor / PullResult 型) は型定義のみで
+ロジックを持たないためテスト対象外。振る舞いを持つ `NullSyncProvider` を固定する。
+
+## どのように
+
+- **push**: remote が無くても reject せず解決する (no-op、返り値 undefined)。
+- **pull**: どんなカーソルを渡しても空 batches と `INITIAL_CURSOR` を返す (前進しない)。
+- **subscribe**: 登録した `onRemote` を一度も呼ばない (配信元が無い)。
+- **unsubscribe**: 返り値の解除ハンドルを呼んでも例外を投げない (no-op)。

--- a/src/client/src/sync/nullSyncProvider.test.ts
+++ b/src/client/src/sync/nullSyncProvider.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'bun:test';
+import type { Batch, NodeId } from '@conversensus/shared';
+import { NullSyncProvider } from './nullSyncProvider';
+import { INITIAL_CURSOR } from './syncProvider';
+
+const sampleBatch = (): Batch => ({
+  id: 'b1' as Batch['id'],
+  actor: 'local',
+  clock: 1,
+  timestamp: 1,
+  ops: [{ kind: 'node.add', target: 'n1' as NodeId, content: 'ノード1' }],
+});
+
+describe('NullSyncProvider', () => {
+  it('push は remote が無くても解決する (no-op)', async () => {
+    const provider = new NullSyncProvider();
+    await expect(provider.push([sampleBatch()])).resolves.toBeUndefined();
+  });
+
+  it('pull は常に空 batches と初期カーソルを返す', async () => {
+    const provider = new NullSyncProvider();
+    const result = await provider.pull('any-cursor');
+    expect(result.batches).toEqual([]);
+    expect(result.cursor).toBe(INITIAL_CURSOR);
+  });
+
+  it('subscribe は onRemote を一度も呼ばない', () => {
+    const provider = new NullSyncProvider();
+    let called = 0;
+    provider.subscribe(() => {
+      called += 1;
+    });
+    expect(called).toBe(0);
+  });
+
+  it('subscribe の解除ハンドルは例外なく呼べる (no-op)', () => {
+    const provider = new NullSyncProvider();
+    const unsubscribe = provider.subscribe(() => {});
+    expect(() => unsubscribe()).not.toThrow();
+  });
+});

--- a/src/client/src/sync/nullSyncProvider.ts
+++ b/src/client/src/sync/nullSyncProvider.ts
@@ -1,0 +1,37 @@
+/**
+ * NullSyncProvider: 完全ローカル (同期なし) の `SyncProvider` 実装 (step1 Phase 4a)
+ *
+ * remote を持たない構成 (未ログイン・完全オフライン運用) の既定 provider。
+ * push は破棄、pull は常に空、subscribe は何も配信しない no-op。
+ * これにより外の層は「provider が常に存在する」前提でコードを書ける
+ * (ATProto 有無で分岐しない)。architecture §6 の "null (完全ローカル)"。
+ */
+
+import type { Batch } from '@conversensus/shared';
+import {
+  type Cursor,
+  INITIAL_CURSOR,
+  type OnRemote,
+  type PullResult,
+  type SyncProvider,
+  type Unsubscribe,
+} from './syncProvider';
+
+export class NullSyncProvider implements SyncProvider {
+  /** ローカル専用なので送信先は無い。ローカル正典は既に確定済み */
+  async push(_batches: Batch[]): Promise<void> {
+    // no-op
+  }
+
+  /** remote が無いので常に空。カーソルは前進させず初期値を返す */
+  async pull(_since: Cursor): Promise<PullResult> {
+    return { batches: [], cursor: INITIAL_CURSOR };
+  }
+
+  /** 配信元が無いので何も呼ばない。解除も no-op */
+  subscribe(_onRemote: OnRemote): Unsubscribe {
+    return () => {
+      // no-op
+    };
+  }
+}

--- a/src/client/src/sync/syncProvider.ts
+++ b/src/client/src/sync/syncProvider.ts
@@ -1,0 +1,54 @@
+/**
+ * sync-provider 境界 (step1 Phase 4a, architecture §6 / D3)
+ *
+ * ATProto を全体に load-bearing させないための**単一インターフェース**。
+ * 外の層はこの `SyncProvider` だけに依存し、`null` (完全ローカル) / ATProto を
+ * 差し替え可能にする。ATProto 実装 (collections/sync/mapper/poller) は本境界の
+ * 内部実装として後続スライス (4c) で封じ込める。
+ *
+ * 運搬単位は統一語彙の `Batch` (step1 Phase 1 で正典化)。
+ * architecture §6 の擬似コードは旧 `GraphEvent[]` だったが、正典一本化に伴い
+ * `Batch[]` へ更新する (Batch = undo/redo・同期・マージの運搬単位)。
+ */
+
+import type { Batch } from '@conversensus/shared';
+
+/**
+ * remote 上の位置を指す不透明トークン。
+ * 中身は provider 定義 (ATProto の rev/seq、Lamport 値など)。
+ * 呼び出し側は解釈せず、次回 `pull` にそのまま渡し、永続化するだけ。
+ */
+export type Cursor = string;
+
+/** 最初から (まだ何も pull していない) を表す初期カーソル */
+export const INITIAL_CURSOR: Cursor = '';
+
+/** `pull` の結果。次回に渡すカーソルを同梱する (cursor-pagination) */
+export type PullResult = {
+  /** since より後に remote で追記された batches */
+  batches: Batch[];
+  /** 次回 `pull` に渡す位置。batches が空でも前進しうる */
+  cursor: Cursor;
+};
+
+/** `subscribe` の解除ハンドル */
+export type Unsubscribe = () => void;
+
+/** remote batches を受け取るコールバック */
+export type OnRemote = (batches: Batch[]) => void;
+
+/**
+ * ローカル正典 (操作ログ) と remote の同期境界。
+ * - オフライン時は push をスキップし outbox に積む (4b)。UI は常にローカルを読むので編集は途切れない。
+ * - subscribe は firehose/jetstream 購読で手動 polling を卒業する (4d)。
+ */
+export interface SyncProvider {
+  /** ローカルの batches を remote へ送る (outbox flush) */
+  push(batches: Batch[]): Promise<void>;
+
+  /** since より後の remote 変更を取得する */
+  pull(since: Cursor): Promise<PullResult>;
+
+  /** remote 追記を購読する。返り値で購読解除する */
+  subscribe(onRemote: OnRemote): Unsubscribe;
+}


### PR DESCRIPTION
## 概要

step1 実装計画の **Phase 4 (sync-provider)** は atproto 配下 ~3458 行の再編 + 外部 I/O を伴い 1 PR に大きすぎるため、非破壊・追加優先でサブフェーズに分割する(実装計画 §8)。本 PR はその先頭 **4a: SyncProvider 境界 + NullSyncProvider**。

ATProto を全体に load-bearing させないための**単一インターフェース**(D3 / architecture §6)を先に作る。外の層はこの境界だけに依存し、`null`(完全ローカル)/ ATProto を差し替え可能にする。ネットワーク非依存で完全にテスト可能、後続スライスを de-risk する。

## 変更点

- **`src/client/src/sync/syncProvider.ts`** — `SyncProvider` インターフェース
  - `push(batches)` (outbox flush) / `pull(since)` (remote 変更取得) / `subscribe(onRemote)` (firehose/jetstream 購読)
  - `Cursor`(不透明・provider 定義のトークン)/ `INITIAL_CURSOR` / `PullResult`(cursor-pagination)/ `Unsubscribe` / `OnRemote` 型
  - 運搬単位は統一語彙の `Batch`(Phase 1 で正典化)。architecture §6 の擬似コードは旧 `GraphEvent[]` だったが、正典一本化に伴い `Batch[]` へ更新。
- **`src/client/src/sync/nullSyncProvider.ts`** — `NullSyncProvider`
  - 完全ローカル(未ログイン・オフライン運用)の既定 provider。push=no-op / pull=空+初期カーソル / subscribe=非配信。
  - 外の層が「provider は常に存在する」前提で書けるようにし、ATProto 有無の分岐を消す。
- **`src/client/src/sync/index.ts`** — バレル。
- **`deepse/plans/step1-implementation.md`** — Phase 4 サブフェーズ分割表(§8)と 4a 完了メモを追記。

## 非破壊

既存の atproto コードは未変更。provider への封じ込め(4c)と外の層の配線切替は後続スライス。

## 後続スライス

- 4b: outbox + オフライン分岐
- 4c: ATProto を provider 実装へ整理(collections/sync/mapper/branchState/poller を `AtprotoSyncProvider` 内部へ)
- 4d: 構造改修(全件 list の解消 / polling → Jetstream / cidCache 永続化)

## テスト

- `nullSyncProvider.test.ts` を 4 ケース追加(push は no-op で解決 / pull は空+初期カーソル / subscribe は非配信 / unsubscribe は no-op)。`.test.md` にテスト仕様。境界の型定義はロジック無しのためテスト対象外。
- 全 **351 pass** / typecheck 0 / lint clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)