### PR TITLE
step1 W3d-2: クライアント trunk 読取を op-log 正典へ切替 (dual-read 安全弁)

### DIFF
--- a/src/client/src/config.ts
+++ b/src/client/src/config.ts
@@ -1,0 +1,15 @@
+/**
+ * クライアント設定フラグ (step1 W3d)
+ */
+
+/**
+ * W3d dual-read 安全弁 (§3.4): trunk ファイルの読み取りを op-log 正典
+ * (`fetchBatches`→`projectFile`) から行うか。
+ *
+ * - 既定 `true`: op-log を読み取り正典にする (W3d cutover)。
+ * - `VITE_READ_FROM_OPLOG=false` で従来の snapshot 読取へ即時退行できる。
+ *   マージ後の実機検証中に退行が出たら flag off で戻す。snapshot は dual-write
+ *   で維持されるため、off に戻した snapshot は常に最新 (安全弁が「戻せる」を担保)。
+ */
+export const READ_FROM_OPLOG =
+  (import.meta.env.VITE_READ_FROM_OPLOG ?? 'true') !== 'false';

--- a/src/client/src/hooks/testing/inMemoryDeps.ts
+++ b/src/client/src/hooks/testing/inMemoryDeps.ts
@@ -1,4 +1,9 @@
-import type { GraphFile, GraphFileListItem } from '@conversensus/shared';
+import {
+  type Batch,
+  type GraphFile,
+  type GraphFileListItem,
+  graphFileToBatches,
+} from '@conversensus/shared';
 import type { FileSheetOpsDeps } from '../useFileSheetOperations';
 
 // biome-ignore lint/suspicious/noExplicitAny: fetchBranchSheetFromPds の戻り値は any で十分
@@ -45,6 +50,17 @@ export function createInMemoryFileSheetOpsDeps(): FileSheetOpsDeps & {
       const file = fileStore.get(id);
       if (!file) throw new Error(`File not found: ${id}`);
       return file;
+    },
+
+    // サーバの lazy migration (snapshot→genesis) を模す。snapshot が無ければ空 op-log。
+    // zod mock 下で genesis の batch id が実 UUID にならないため、決定論的な plain id に
+    // 振り直して projection の tiebreak を安定させる。
+    fetchBatches: async (id: string) => {
+      const file = fileStore.get(id);
+      if (!file) return [];
+      return graphFileToBatches(file).map(
+        (b, i) => ({ ...b, id: `genesis-${i}` }) as Batch,
+      );
     },
 
     fetchFiles: async () => [...fileList],

--- a/src/client/src/hooks/useFileSheetOperations.test.md
+++ b/src/client/src/hooks/useFileSheetOperations.test.md
@@ -34,6 +34,26 @@ tap は `syncRecord` として注入し、実ネットワーク (LocalServerSync
 - handleSaveSheetSettings: シート名と説明を更新し、変化した項目のみ op-log へ emit すること (`SHEET_RENAMED` / `SHEET_DESCRIBED`)
 - handleSaveSheetSettings: 変化が無ければ何も emit しないこと (空 batch 回避)
 
+### 読み取り経路の cutover — W3d dual-read (`READ_FROM_OPLOG`)
+
+`openFile` (trunk 読取) は W3d で snapshot から **op-log 正典** (`fetchBatches`→`projectFile`)
+へ切替わる。`GET /files/:id/batches` はサーバ側で lazy migration (snapshot→genesis, W3d-1)
+を起動するため、既存ファイルも op-log projection で開ける。安全弁として `READ_FROM_OPLOG`
+フラグ (テストは hook 引数 `readFromOplog` で明示) と snapshot フォールバックを持つ。
+
+- **flag ON**: op-log (`fetchBatches`) から読み、snapshot (`fetchFile`) には触れないこと。
+  in-memory deps は snapshot から genesis を合成 (`graphFileToBatches`) して op-log を模す。
+- **flag ON + op-log 読取失敗**: `fetchBatches` が throw したら snapshot にフォールバックし、
+  正常に開けること (dual-read 安全弁)。
+- **flag ON + op-log が空 (0 シート)**: 有効な `GraphFile` は 1 枚以上シートを持つため、
+  0 シート projection は「読取失敗」扱いで snapshot に退避すること。真の欠損は snapshot 側で
+  404 → alert に至る (既存の「見つからない場合はエラー通知」ケースが空 op-log→フォールバックを兼ねる)。
+- **flag OFF**: 従来通り snapshot (`fetchFile`) から読み、op-log (`fetchBatches`) には
+  一切触れないこと (即時退行の担保)。
+
+`handleCreate` も作成直後に同じ `loadFile` (op-log 経路) で読み直し、genesis を起動して
+projection を表示する (open との一貫性)。作成レスポンス由来の snapshot がフォールバック先。
+
 ### dual-write の設計意図
 構造操作は W3d の読み取り cutover まで snapshot が正典。op-log への emit は
 「op-log を書き込み経路の正典にする (D4)」ための前進で、変化項目のみ emit することで

--- a/src/client/src/hooks/useFileSheetOperations.test.ts
+++ b/src/client/src/hooks/useFileSheetOperations.test.ts
@@ -30,8 +30,13 @@ afterEach(() => {
   mockSetAlertState.mockClear();
 });
 
-async function render() {
-  const deps = createInMemoryFileSheetOpsDeps();
+type RenderOpts = {
+  deps?: ReturnType<typeof createInMemoryFileSheetOpsDeps>;
+  readFromOplog?: boolean;
+};
+
+async function renderWith(opts: RenderOpts = {}) {
+  const deps = opts.deps ?? createInMemoryFileSheetOpsDeps();
   // op-log tap を差し替え、実ネットワーク (LocalServerSyncProvider) を避けつつ
   // 構造操作の dual-write emit を検証する
   const syncRecord = mock((_event: { type: string }) => {});
@@ -41,6 +46,9 @@ async function render() {
       setAlertState: mockSetAlertState,
       deps,
       syncRecord: syncRecord as unknown as (event: never) => void,
+      ...(opts.readFromOplog !== undefined && {
+        readFromOplog: opts.readFromOplog,
+      }),
     }),
   );
   // Flush async effects (fetchFiles + ATProto sync)
@@ -48,6 +56,10 @@ async function render() {
     await new Promise((r) => setTimeout(r, 10));
   });
   return { ...result, deps, syncRecord };
+}
+
+async function render() {
+  return renderWith();
 }
 
 /** syncRecord に渡された event の type 一覧 */
@@ -152,6 +164,121 @@ describe('useFileSheetOperations', () => {
       });
 
       expect(mockSetAlertState).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('openFile — W3d dual-read (READ_FROM_OPLOG)', () => {
+    it('flag ON: op-log (fetchBatches→projectFile) から読み、snapshot は読まない', async () => {
+      const deps = createInMemoryFileSheetOpsDeps();
+      deps.fetchBatches = mock(deps.fetchBatches);
+      deps.fetchFile = mock(deps.fetchFile);
+      const { result } = await renderWith({ deps, readFromOplog: true });
+
+      await act(async () => {
+        await result.current.handleCreate();
+      });
+      const fileId = result.current.activeFile?.id;
+      if (!fileId) throw new Error('activeFile should be set');
+
+      act(() => {
+        result.current.setActiveFile(null);
+      });
+      (deps.fetchBatches as ReturnType<typeof mock>).mockClear();
+      (deps.fetchFile as ReturnType<typeof mock>).mockClear();
+
+      await act(async () => {
+        await result.current.openFile(fileId);
+      });
+
+      // op-log 経路で開けており、snapshot 経路 (fetchFile) は触れていない
+      expect(deps.fetchBatches).toHaveBeenCalled();
+      expect(deps.fetchFile).not.toHaveBeenCalled();
+      expect(result.current.activeFile?.id).toBe(fileId);
+      expect(result.current.activeSheetId).toBeTruthy();
+    });
+
+    it('flag ON + op-log 読取失敗: snapshot にフォールバックして開ける', async () => {
+      const deps = createInMemoryFileSheetOpsDeps();
+      // op-log 読取は常に失敗させる → snapshot (fetchFile) へフォールバック
+      deps.fetchBatches = mock(async () => {
+        throw new Error('boom');
+      });
+      deps.fetchFile = mock(deps.fetchFile);
+      const { result } = await renderWith({ deps, readFromOplog: true });
+
+      await act(async () => {
+        await result.current.handleCreate();
+      });
+      const fileId = result.current.activeFile?.id;
+      if (!fileId) throw new Error('activeFile should be set via fallback');
+
+      act(() => {
+        result.current.setActiveFile(null);
+      });
+      (deps.fetchFile as ReturnType<typeof mock>).mockClear();
+
+      await act(async () => {
+        await result.current.openFile(fileId);
+      });
+
+      expect(deps.fetchFile).toHaveBeenCalled();
+      expect(result.current.activeFile?.id).toBe(fileId);
+    });
+
+    it('flag ON + op-log が空 (0 シート): snapshot にフォールバックする', async () => {
+      const deps = createInMemoryFileSheetOpsDeps();
+      deps.fetchFile = mock(deps.fetchFile);
+      const { result } = await renderWith({ deps, readFromOplog: true });
+
+      // snapshot は残しつつ op-log を空にする → 0 シート projection でフォールバック
+      await act(async () => {
+        await result.current.handleCreate();
+      });
+      const fileId = result.current.activeFile?.id;
+      if (!fileId) throw new Error('activeFile should be set');
+
+      act(() => {
+        result.current.setActiveFile(null);
+      });
+      deps.fetchBatches = mock(async () => []);
+      (deps.fetchFile as ReturnType<typeof mock>).mockClear();
+
+      await act(async () => {
+        await result.current.openFile(fileId);
+      });
+
+      // 空 op-log は「読取失敗」扱いで snapshot に退避し、正常に開ける
+      expect(deps.fetchFile).toHaveBeenCalled();
+      expect(result.current.activeFile?.id).toBe(fileId);
+      expect(result.current.activeSheetId).toBeTruthy();
+    });
+
+    it('flag OFF: snapshot から読み、op-log (fetchBatches) は読まない', async () => {
+      const deps = createInMemoryFileSheetOpsDeps();
+      deps.fetchBatches = mock(deps.fetchBatches);
+      deps.fetchFile = mock(deps.fetchFile);
+      const { result } = await renderWith({ deps, readFromOplog: false });
+
+      await act(async () => {
+        await result.current.handleCreate();
+      });
+      const fileId = result.current.activeFile?.id;
+      if (!fileId) throw new Error('activeFile should be set');
+
+      act(() => {
+        result.current.setActiveFile(null);
+      });
+      (deps.fetchBatches as ReturnType<typeof mock>).mockClear();
+      (deps.fetchFile as ReturnType<typeof mock>).mockClear();
+
+      await act(async () => {
+        await result.current.openFile(fileId);
+      });
+
+      // 従来経路: snapshot を読み、op-log には一切触れない (即時退行の担保)
+      expect(deps.fetchBatches).not.toHaveBeenCalled();
+      expect(deps.fetchFile).toHaveBeenCalled();
+      expect(result.current.activeFile?.id).toBe(fileId);
     });
   });
 

--- a/src/client/src/hooks/useFileSheetOperations.ts
+++ b/src/client/src/hooks/useFileSheetOperations.ts
@@ -1,13 +1,16 @@
-import type {
-  ConversensusFile,
-  GraphFile,
-  GraphFileListItem,
-  SheetId,
+import {
+  type ConversensusFile,
+  type FileId,
+  type GraphFile,
+  type GraphFileListItem,
+  projectFile,
+  type SheetId,
 } from '@conversensus/shared';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   createFile,
   exportFile,
+  fetchBatches,
   fetchFile,
   fetchFiles,
   importFile,
@@ -20,6 +23,7 @@ import {
   fetchFilesFromAtproto,
   syncFileToAtproto,
 } from '../atproto';
+import { READ_FROM_OPLOG } from '../config';
 import type { GraphEvent } from '../events/GraphEvent';
 import { makeEventBase } from '../events/GraphEvent';
 import type { PopupTarget } from '../SettingsPopup';
@@ -38,6 +42,7 @@ type AlertState = {
 export interface FileSheetOpsDeps {
   createFile: typeof createFile;
   exportFile: typeof exportFile;
+  fetchBatches: typeof fetchBatches;
   fetchFile: typeof fetchFile;
   fetchFiles: typeof fetchFiles;
   importFile: typeof importFile;
@@ -52,6 +57,7 @@ export interface FileSheetOpsDeps {
 export const defaultFileSheetOpsDeps: FileSheetOpsDeps = {
   createFile,
   exportFile,
+  fetchBatches,
   fetchFile,
   fetchFiles,
   importFile,
@@ -72,6 +78,11 @@ interface UseFileSheetOperationsParams {
    * content 経路 (GraphEditor) は sheetId を渡し、structure 経路 (以下のハンドラ) は渡さない (W3c2)。
    */
   syncRecord?: (event: GraphEvent, sheetId?: SheetId) => void;
+  /**
+   * W3d dual-read 安全弁: trunk 読取を op-log 正典から行うか (§3.4)。
+   * 未指定なら `READ_FROM_OPLOG` 定数 (env)。テストは明示指定で on/off を固定する。
+   */
+  readFromOplog?: boolean;
 }
 
 export function useFileSheetOperations({
@@ -79,6 +90,7 @@ export function useFileSheetOperations({
   setAlertState,
   deps = defaultFileSheetOpsDeps,
   syncRecord: syncRecordOverride,
+  readFromOplog = READ_FROM_OPLOG,
 }: UseFileSheetOperationsParams) {
   const [files, setFiles] = useState<GraphFileListItem[]>([]);
   const [activeFile, setActiveFile] = useState<GraphFile | null>(null);
@@ -99,18 +111,52 @@ export function useFileSheetOperations({
   const internalSyncRecord = useEventSyncTap(activeFile?.id ?? null);
   const syncRecord = syncRecordOverride ?? internalSyncRecord;
 
+  // 従来の snapshot 読取 (ATProto → ローカルキャッシュ)。dual-read のフォールバック側。
+  const loadSnapshot = useCallback(
+    async (id: string): Promise<GraphFile> => {
+      try {
+        const file = await deps.fetchFileFromAtproto(id);
+        deps
+          .saveFile(file)
+          .catch((err) => console.warn('[cache] save failed:', err));
+        return file;
+      } catch {
+        return deps.fetchFile(id);
+      }
+    },
+    [deps],
+  );
+
+  // W3d trunk 読取: op-log 正典 (fetchBatches→projectFile) を優先し、失敗時は snapshot へ
+  // フォールバックする (§3.4)。GET /files/:id/batches はサーバ側で lazy migration
+  // (snapshot→genesis) を起動する (W3d-1) ため、既存ファイルも op-log projection で開ける。
+  const loadFile = useCallback(
+    async (id: string): Promise<GraphFile> => {
+      if (readFromOplog) {
+        try {
+          const batches = await deps.fetchBatches(id as FileId);
+          const file = projectFile(batches, id as FileId);
+          // 有効な GraphFile は必ず 1 枚以上のシートを持つ。0 枚 = op-log 未生成
+          // (snapshot 欠損 / 未 migration / 欠損 file) とみなし snapshot へ委ねる。
+          // 「読取失敗」と同様にフォールバックし、真の欠損は snapshot 側で 404 → alert に至る。
+          if (file.sheets.length === 0) {
+            throw new Error('op-log projection has no sheets');
+          }
+          return file;
+        } catch (err) {
+          // dual-read 安全弁: op-log 読取が失敗したときのみ snapshot に退避する
+          console.warn('[oplog] read failed; falling back to snapshot:', err);
+        }
+      }
+      return loadSnapshot(id);
+    },
+    [deps, readFromOplog, loadSnapshot],
+  );
+
   const openFile = useCallback(
     async (id: string) => {
       try {
-        let file: GraphFile;
-        try {
-          file = await deps.fetchFileFromAtproto(id);
-          deps
-            .saveFile(file)
-            .catch((err) => console.warn('[cache] save failed:', err));
-        } catch {
-          file = await deps.fetchFile(id);
-        }
+        const file = await loadFile(id);
         setActiveFile(file);
         setActiveSheetId((file.sheets[0]?.id ?? null) as SheetId | null);
         setExpandedFileIds((prev) => new Set([...prev, id]));
@@ -124,7 +170,7 @@ export function useFileSheetOperations({
         });
       }
     },
-    [deps, setAlertState],
+    [loadFile, setAlertState],
   );
 
   const toggleExpand = useCallback(
@@ -150,19 +196,26 @@ export function useFileSheetOperations({
   const handleCreate = useCallback(async () => {
     try {
       const name = newFileName.trim() || '無題';
-      const file = await deps.createFile(name);
+      const created = await deps.createFile(name);
       setFiles((fs) => [
         ...fs,
-        { id: file.id, name: file.name, description: file.description },
+        {
+          id: created.id,
+          name: created.name,
+          description: created.description,
+        },
       ]);
+      // 作成直後も同じ op-log 経路で読み直し、genesis を起動して projection を表示する
+      // (open との一貫性)。失敗時は loadFile が snapshot(=作成レスポンス相当)へ退避する。
+      const file = await loadFile(created.id);
       setActiveFile(file);
       setActiveSheetId((file.sheets[0]?.id ?? null) as SheetId | null);
-      setExpandedFileIds((prev) => new Set([...prev, file.id]));
+      setExpandedFileIds((prev) => new Set([...prev, created.id]));
       setNewFileName('');
     } catch (err) {
       console.error('Failed to create file:', err);
     }
-  }, [newFileName, deps]);
+  }, [newFileName, deps, loadFile]);
 
   const persistFile = useCallback(
     async (updated: GraphFile) => {


### PR DESCRIPTION
## 概要

Phase 4 実配線 W3 の **W3d-2**。trunk ファイルの読み取りを snapshot から
**op-log 正典** (`fetchBatches`→`projectFile`) へ切替える。`GET /files/:id/batches` は
サーバ側 lazy migration (snapshot→genesis, W3d-1 / PR #159) を起動するため、既存ファイルも
op-log projection で開ける。読み取り cutover の本体 (hot path)。

設計: `deepse/plans/step1-w3d-read-cutover.md` §3.4 / 実装スライス W3d-2。

## 変更内容

- **`config.ts`** (新規): `READ_FROM_OPLOG` フラグ。既定 `true`、`VITE_READ_FROM_OPLOG=false`
  で従来の snapshot 読取へ即時退行できる (dual-read 安全弁)。snapshot は dual-write で維持されるため
  off に戻した snapshot は常に最新。
- **`useFileSheetOperations.ts`**:
  - `loadSnapshot` (従来の ATProto→キャッシュ経路 = フォールバック側) と `loadFile`
    (op-log 優先 + フォールバック) を抽出
  - `openFile` を `loadFile` 経由に。`handleCreate` も作成直後に `loadFile` で読み直し
    (genesis 起動、open との一貫性)
  - `fetchBatches` を `FileSheetOpsDeps` に追加、`readFromOplog` 引数を追加 (テストで on/off 固定)
- **`inMemoryDeps.ts`**: テスト用 `fetchBatches` (snapshot から genesis を合成し lazy migration を模す)

## 設計判断

- **空/失敗の区別 (§3.4 からの微修正)**: 設計は「op-log が空 = 正常」としていたが、**0 シートは
  UI で使えない**ため「読取失敗扱いでフォールバック」に変更。W3d では全実ファイルが snapshot 由来で
  genesis により必ず ≥1 シートになるので、空＝欠損と一致し、既存の「見つからない→alert」挙動も保てる。
  真の欠損は snapshot 側 404 → alert に至る。
- **branch 不変 (§3.3)**: read cutover は trunk 読取のみ切替え、`App.tsx` / `branchState.ts` /
  `useBranchOperations` には一切触れない。branch 読取は従来通り `fetchBranchSheetFromPds`。
- **`handleImportFile` は対象外**: W3d-2 スコープ (`handleCreate`) に絞り、import は snapshot
  レスポンスをそのまま使用 (初回 open で lazy migration される)。

## テスト

- **`useFileSheetOperations.test.ts`** (+4):
  - flag ON: op-log (`fetchBatches`) から読み、snapshot (`fetchFile`) は読まない
  - flag ON + op-log 読取失敗: snapshot にフォールバックして開ける
  - flag ON + op-log が空 (0 シート): snapshot にフォールバックする
  - flag OFF: snapshot から読み、op-log には触れない (即時退行の担保)
- 既存の openFile / handleCreate テストも op-log 既定経路を通過 (in-memory genesis 合成で round-trip)
- `.test.md` 更新

typecheck / lint / test (**432 pass**) 全パス。

## 次スライス

- **W3d-3**: レイテンシ実測 (§3.5) + 予算判定 (超過時のみ projection cache)
- **W3d-4**: 実機 e2e (デーモン + ブラウザ)。既存ファイル migration→表示、編集→再オープン一致、
  branch トグル従来通り、flag off で snapshot 復帰。W3d 完了条件

🤖 Generated with [Claude Code](https://claude.com/claude-code)