### PR TITLE
step1 W3d-3/W3d-4: projectFile レイテンシ実測 + 読取 cutover の実機 e2e 検証

### DIFF
--- a/deepse/plans/step1-w3d-read-cutover.md
+++ b/deepse/plans/step1-w3d-read-cutover.md
@@ -156,6 +156,25 @@ W3d 自体を小さく分割し、各段でテスト・検証を挟む。
 
 ## 8. 未解決点 (W3d 実装中に確定)
 
-- レイテンシ実測の結果次第で §3.6 cache を W3d に含めるか W3e 前送りか (§3.5 の予算判定)。
+- ~~レイテンシ実測の結果次第で §3.6 cache を W3d に含めるか W3e 前送りか (§3.5 の予算判定)。~~ → **W3d-3 で確定 (§9)。cache 不要**。
 - 破棄前 snapshot バックアップの要否・運用形 (§6)。単一ユーザー・ローカルなので storage.ts の JSON が残るが、明示バックアップ手順を W3d-4 で判断。
-- `handleCreate` 直後の read 経路統一の具体 (作成レスポンスをそのまま使うか、必ず fetchBatches で読み直すか) — W3d-2 で確定。
+- ~~`handleCreate` 直後の read 経路統一の具体 (作成レスポンスをそのまま使うか、必ず fetchBatches で読み直すか) — W3d-2 で確定。~~ → W3d-2 で fetchBatches 読み直しに統一済。
+
+## 9. W3d-3 レイテンシ実測結果 (2026-07-16)
+
+**結論: projection cache (§3.6) は不要。W3d-2 の op-log 読取 cutover を予算内で受け入れる。**
+
+- **計測**: `projectFile(batches, fileId)` 単体。合成 batch (genesis + 1 op/batch の増分編集) を N 段階で生成し、warmup 5 回後に 50 回計測の median。実行環境 macOS arm64 / Bun v1.3.8。ベンチは `src/shared/src/events/projectFile.bench.ts` (投棄可・CI 非搭載)。
+- **予算 (§3.5)**: 典型ファイル (数百 batch) で projectFile < 50ms。
+
+| N (batch) | 1 sheet (200 nodes base) | 5 sheets (100 nodes/sheet base) |
+|-----------|--------------------------|----------------------------------|
+| 100       | 0.15ms                   | 0.23ms                           |
+| 500       | 0.22ms                   | 0.28ms                           |
+| 1,000     | 0.27ms                   | 0.36ms                           |
+| 5,000     | 0.77ms                   | 0.93ms                           |
+
+- **予算比**: 数百 batch (典型) で **0.2ms 前後 = 予算の 1/200 以下**。最悪の N=5,000 でも 1ms 未満。
+- **ヘッドルーム確認 (単一シート・極端規模)**: N=10,000 → 1.5ms、N=20,000 → 2.5ms、N=50,000 → 5.9ms。batch 数に**線形** (約 0.12ms/1,000 batch) で、50,000 batch でも予算の 1/8。
+- **判定**: 全ケースで予算内、かつ実運用が到達しうる規模では圧倒的余裕。§3.6 の projection cache は W3d でも W3e 前でも**導入不要**。将来 op-log が数万 batch/ファイルに達し、かつ openFile の体感が問題化した時点で再検討する (線形なので予測可能)。
+- **openFile end-to-end の扱い**: fetch (HTTP + SQLite) は I/O 律速で projection の CPU コストとは別軸。projection が支配項でないことが本計測で確定したため、体感悪化が出た場合の一次被疑は fetch/転送側であり projection cache ではない。end-to-end 体感の合否は実機で W3d-4 に委ねる。

--- a/deepse/plans/step1-w3d-read-cutover.md
+++ b/deepse/plans/step1-w3d-read-cutover.md
@@ -198,6 +198,12 @@ W3d-1/2 は各層のユニット/結合テストで固めた。W3d-4 は**層を
 - **範囲の線引き**: edge の style / labelOffset は projection では presentation 経路 (GraphFile 非搭載) のため equality から除外。過剰主張を避ける。
 - 全 436 テスト green。lint / typecheck パス。
 
+**実デーモン HTTP 確認 (in-process `server.fetch` の外側)**: `bun run src/server/src/index.ts` を
+一時 `DATA_DIR` で起動し、実ポート :3000 越しに curl で検証。`POST /files` → `PUT` (2 node/1 edge/layout)
+→ `GET /files/:id/batches` で lazy migration が発火し 3 batch (`file.setName`/`file.setDescription`/
+`sheet.create`/`node.add`×2/`node.setLayout`/`edge.add`) を返す。`projectFile` round-trip で
+名前・シート・node/edge/layout・content・label が再現。再 GET も同 3 batch (べき等)。実プロセス+実 HTTP でも契約が成立。
+
 ### 10.2 ブラウザ目視パス (手動チェックリスト)
 
 自動 e2e が HTTP 内側を保証するので、残りは React Flow 描画と GUI トグルの目視。

--- a/deepse/plans/step1-w3d-read-cutover.md
+++ b/deepse/plans/step1-w3d-read-cutover.md
@@ -209,8 +209,15 @@ W3d-1/2 は各層のユニット/結合テストで固めた。W3d-4 は**層を
 自動 e2e が HTTP 内側を保証するので、残りは React Flow 描画と GUI トグルの目視。
 `bun run dev:server` + `bun run dev:client` で以下を確認し screenshot を記録する。
 
-- [ ] 既存ファイルを開くと projection が正しく描画される (ノード配置・エッジ・シートタブ)
-- [ ] 編集して再オープン → 編集が残る
-- [ ] trunk↔branch トグル (`App.tsx` の `graphKey`) が従来通り動く (§3.3: branch コードに変更なし)
-- [ ] `VITE_READ_FROM_OPLOG=false` で起動 → snapshot 表示に復帰 (安全弁の画面確認)
-- [ ] 破棄前 snapshot バックアップ (§6/§8): 単一ユーザー・ローカルで storage.ts の JSON が残るため明示手順は不要と判断 (migration は snapshot を破壊しない = ケース 4 で機械的に確認済)。
+- [x] 既存ファイルを開くと projection が正しく描画される (ノード配置・エッジ・シートタブ)
+- [x] 編集して再オープン → 編集が残る
+- [x] trunk↔branch トグル (`App.tsx` の `graphKey`) が従来通り動く (§3.3: branch コードに変更なし)
+- [x] `VITE_READ_FROM_OPLOG=false` で起動 → snapshot 表示に復帰 (安全弁の画面確認)
+- [x] 破棄前 snapshot バックアップ (§6/§8): 単一ユーザー・ローカルで storage.ts の JSON が残るため明示手順は不要と判断 (migration は snapshot を破壊しない = ケース 4 で機械的に確認済)。
+
+**目視結果 (2026-07-18, Chrome MCP で実機確認)**: 実行中の dev サーバ (:3000 デーモン / :5173 クライアント) に対し、snapshot だけの pre-W3 相当ファイルを curl で seed して確認した。
+
+1. **projection 描画**: seed をブラウザで開くと、こちらが一切触っていないファイルに genesis 3 batch (`file.setName` / `sheet.create` / `node.add`×2+`node.setLayout`×2+`edge.add`) が生成された。**ブラウザ自身の read が lazy migration を発火**させた証拠。ノード配置・ラベル付きエッジ・シートタブすべて正常描画。
+2. **編集の永続**: ペーンのダブルクリックから Markdown ノードを追加・テキスト入力すると op-log に actor `local` の追記 batch (clock4 `node.add`+`node.setLayout` / clock5 `node.setContent`)。別ページを新規ロードして開き直すと編集ノードが残存。**再オープンは batch 数を増やさない (= 読取専用)** ことも確認。
+3. **branch トグル**: 「+ branch」で **アプリ内 React モーダル**「branch 名を入力してください」が従来通り起動 (ネイティブ `prompt()` ではないのでセッションはフリーズしない)。キャンセルで trunk 描画に復帰。branch 作成自体は PDS 依存で step2 スコープ。
+4. **安全弁 (flag off)**: 読取経路を画面で判別するため snapshot の node0 content だけを curl PUT で `[SNAPSHOT経路]…` に書き換え (op-log は marker 済で不変)。既存 :5173 (flag on) は触らず、別ポートで `VITE_READ_FROM_OPLOG=false bunx vite --port 5174` を起動。**同一ファイルで flag on=マーカー無し (op-log 読取) / flag off=マーカー有り (snapshot 直読)** を対比でき、読取ソースがフラグで実際に切り替わり安全弁が生きていることを確認。検証後 snapshot を復元。

--- a/deepse/plans/step1-w3d-read-cutover.md
+++ b/deepse/plans/step1-w3d-read-cutover.md
@@ -178,3 +178,33 @@ W3d 自体を小さく分割し、各段でテスト・検証を挟む。
 - **ヘッドルーム確認 (単一シート・極端規模)**: N=10,000 → 1.5ms、N=20,000 → 2.5ms、N=50,000 → 5.9ms。batch 数に**線形** (約 0.12ms/1,000 batch) で、50,000 batch でも予算の 1/8。
 - **判定**: 全ケースで予算内、かつ実運用が到達しうる規模では圧倒的余裕。§3.6 の projection cache は W3d でも W3e 前でも**導入不要**。将来 op-log が数万 batch/ファイルに達し、かつ openFile の体感が問題化した時点で再検討する (線形なので予測可能)。
 - **openFile end-to-end の扱い**: fetch (HTTP + SQLite) は I/O 律速で projection の CPU コストとは別軸。projection が支配項でないことが本計測で確定したため、体感悪化が出た場合の一次被疑は fetch/転送側であり projection cache ではない。end-to-end 体感の合否は実機で W3d-4 に委ねる。
+
+## 10. W3d-4 end-to-end 検証 (2026-07-16)
+
+W3d-1/2 は各層のユニット/結合テストで固めた。W3d-4 は**層をまたいだ実物の結線**を確認する。
+
+### 10.1 自動 e2e (デーモンレベル) — `src/server/src/readCutover.e2e.test.ts`
+
+実 HTTP ハンドラ (`server.fetch`) + 実 SQLite (`events.db`) + 実 snapshot (`storage.ts`) +
+クライアント読取関数 `projectFile` を一気通貫で通す。HTTP 転送より内側を全部実物で駆動する。
+
+| # | 検証 | 結果 |
+|---|------|------|
+| 1 | 既存 snapshot を開く → lazy migration → `projectFile` が snapshot の構造を再現 (シート順・nodes・edges・layouts) | ✅ |
+| 2 | migration べき等: 再オープンで projection 完全一致 (marker で再 genesis しない) | ✅ |
+| 3 | 編集 (batch 追記) → 再オープンで projection に反映 | ✅ |
+| 4 | flag off (snapshot 直読 `GET /files/:id`) が migration 後も元 snapshot を返す (dual-read 安全弁健在) | ✅ |
+
+- **範囲の線引き**: edge の style / labelOffset は projection では presentation 経路 (GraphFile 非搭載) のため equality から除外。過剰主張を避ける。
+- 全 436 テスト green。lint / typecheck パス。
+
+### 10.2 ブラウザ目視パス (手動チェックリスト)
+
+自動 e2e が HTTP 内側を保証するので、残りは React Flow 描画と GUI トグルの目視。
+`bun run dev:server` + `bun run dev:client` で以下を確認し screenshot を記録する。
+
+- [ ] 既存ファイルを開くと projection が正しく描画される (ノード配置・エッジ・シートタブ)
+- [ ] 編集して再オープン → 編集が残る
+- [ ] trunk↔branch トグル (`App.tsx` の `graphKey`) が従来通り動く (§3.3: branch コードに変更なし)
+- [ ] `VITE_READ_FROM_OPLOG=false` で起動 → snapshot 表示に復帰 (安全弁の画面確認)
+- [ ] 破棄前 snapshot バックアップ (§6/§8): 単一ユーザー・ローカルで storage.ts の JSON が残るため明示手順は不要と判断 (migration は snapshot を破壊しない = ケース 4 で機械的に確認済)。

--- a/src/server/src/readCutover.e2e.test.md
+++ b/src/server/src/readCutover.e2e.test.md
@@ -1,0 +1,54 @@
+# readCutover.e2e.test — W3d-4 読み取り cutover end-to-end 検証
+
+## 何を
+
+step1 W3d (op-log 読み取り正典化) の end-to-end 契約を、**デーモンレベル**で検証する。
+実 HTTP ハンドラ (`server.fetch`) + 実 SQLite (`events.db`) + 実 snapshot (`storage.ts`) +
+クライアント読取関数 `projectFile` を一気通貫で通し、openFile が実運用の部品で正しく動くことを確認する。
+
+設計: `deepse/plans/step1-w3d-read-cutover.md` §5 (W3d-4 スライス) / §6 (リスクと検証)。
+
+## なぜ
+
+W3d-1 (サーバ lazy migration) と W3d-2 (クライアント読取切替) は各層のユニット/結合テストで
+個別に固めた。W3d-4 は **層をまたいだ実物の結線**を検証する段。ユニットテストは
+モック・部分実装で通っても、実 SQLite・実 HTTP・実 projection を繋いだときに
+migration→projection の契約が崩れていないことは別途保証が要る。
+
+ブラウザ GUI (React Flow 描画・branch トグル・flag off の画面復帰) は本テストの範囲外で、
+手動の目視パス (screenshot 記録) で確認する。本テストは HTTP 転送より内側の
+「migration→projection が snapshot を忠実に再現する」正当性を機械的に固定する。
+
+## どのように
+
+`beforeEach` でテスト毎に一時 `DATA_DIR` を作り、`events.db` と snapshot JSON を隔離する
+(`getEventStore` はパス単位でメモ化するので DATA_DIR 差し替えで別 DB になる)。
+
+`richSnapshot()` で実運用相当の GraphFile を組む: 2 シート、複数ノード (content/properties)、
+ラベル付きエッジ、ノードレイアウト (x/y/width/height)、エッジルーティング (pathType)。
+`putSnapshot()` は `POST /files` で空ファイルを作り、`PUT /files/:id` で rich snapshot に
+差し替える (**marker は立てない** = 既存の未 migration ファイルを模す)。
+
+比較は `structural()` で正規化する: `projectFile` が `GraphFile` に再現するフィールド
+(ファイルメタ・シート順・nodes・edges・node layouts・edge routing) だけを id 昇順にソートして
+突き合わせる。edge の style / labelOffset は projection では presentation 経路 (GraphFile 非搭載)
+なので equality には含めない — 過剰主張を避けるための線引き。
+
+### ケース
+
+1. **既存 snapshot を開くと migration→projectFile が構造を再現する**:
+   rich snapshot を PUT → 初回 `GET /files/:id/batches` が lazy migration を発火 →
+   返る batches を `projectFile` → 元の snapshot と構造が一致。シート順 (メイン→サブ) も保たれる。
+2. **migration はべき等**: 二度 `openViaOplog` して projection が完全一致
+   (marker により再 genesis されない)。
+3. **編集を再オープンで反映**: 初回 open で genesis の最大 clock を確認 → その後に
+   nodeA の `node.setContent` batch を追記 → 再 open した projection で content が更新済み。
+4. **flag off (snapshot 直読) は最新 snapshot を返す**: migration 後も `GET /files/:id`
+   (= `READ_FROM_OPLOG=false` 相当の snapshot 直読) が元の GraphFile を返す。
+   migration は snapshot を破壊しない → dual-read 安全弁が健在。
+
+## 手動で確認する残項目 (本テスト対象外)
+
+`deepse/plans/step1-w3d-read-cutover.md` §10.2 (ブラウザ目視パス) を参照。
+ブラウザで実ファイルを開き projection が描画されること、trunk↔branch トグルが従来通り、
+`VITE_READ_FROM_OPLOG=false` で snapshot 表示に復帰することを screenshot で記録する。

--- a/src/server/src/readCutover.e2e.test.ts
+++ b/src/server/src/readCutover.e2e.test.ts
@@ -1,0 +1,217 @@
+/**
+ * W3d-4 読み取り cutover end-to-end 検証 (デーモンレベル, step1-w3d-read-cutover.md §5)
+ *
+ * 実 HTTP ハンドラ (`server.fetch`) + 実 SQLite (`events.db`) + 実 snapshot (`storage.ts`) +
+ * クライアント読取関数 `projectFile` を結び、openFile の end-to-end 契約を検証する。
+ * ブラウザ GUI の外側 (HTTP 転送より内側) のすべてを実物で通す。
+ *
+ * ブラウザ目視パス (React Flow 描画・branch トグル・flag off の画面復帰・screenshot) は
+ * 別途手動で確認する。本テストは migration→projection の正当性を機械的に固める。
+ *
+ * 検証項目 (§5 W3d-4 / §6):
+ *   1. 既存ファイル (snapshot) を開くと lazy migration が走り、projectFile が snapshot を再現
+ *   2. migration はべき等: 再オープンで同一結果
+ *   3. 編集 (batch 追記) → 再オープンで projection に反映
+ *   4. flag off (snapshot 直読) は dual-write された最新 snapshot を返す (安全弁)
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  type EdgeId,
+  type FileId,
+  type GraphFile,
+  type NodeId,
+  projectFile,
+  type SheetId,
+} from '@conversensus/shared';
+import server from './index';
+
+const fetch = server.fetch;
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), 'conversensus-w3d4-'));
+  process.env.DATA_DIR = tmpDir;
+});
+
+afterEach(async () => {
+  delete process.env.DATA_DIR;
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+const u = (n: number): string =>
+  `${n.toString(16).padStart(8, '0')}-0000-4000-8000-000000000000`;
+
+/** 実運用相当の複数シート・ノード・エッジ・レイアウトを持つ snapshot を組む */
+function richSnapshot(id: FileId): GraphFile {
+  const nodeA = u(1) as NodeId;
+  const nodeB = u(2) as NodeId;
+  const nodeC = u(3) as NodeId;
+  const edgeAB = u(11) as EdgeId;
+  return {
+    id,
+    name: 'W3d-4 e2e',
+    description: 'read cutover 検証用',
+    sheets: [
+      {
+        id: u(101) as SheetId,
+        name: 'メイン',
+        description: 'シート1',
+        nodes: [
+          { id: nodeA, content: 'A', properties: { color: 'red' } },
+          { id: nodeB, content: 'B' },
+          { id: nodeC, content: 'C' },
+        ],
+        edges: [{ id: edgeAB, source: nodeA, target: nodeB, label: 'A→B' }],
+        layouts: [
+          { nodeId: nodeA, x: 10, y: 20, width: 120, height: 40 },
+          { nodeId: nodeB, x: 200, y: 20, width: 120, height: 40 },
+          { nodeId: nodeC, x: 100, y: 120, width: 120, height: 40 },
+        ],
+        edgeLayouts: [{ edgeId: edgeAB, pathType: 'smoothstep' }],
+      },
+      {
+        id: u(102) as SheetId,
+        name: 'サブ',
+        nodes: [{ id: u(4) as NodeId, content: 'D' }],
+        edges: [],
+        layouts: [
+          { nodeId: u(4) as NodeId, x: 0, y: 0, width: 80, height: 30 },
+        ],
+        edgeLayouts: [],
+      },
+    ],
+  };
+}
+
+async function putSnapshot(file: GraphFile): Promise<void> {
+  // POST /files で空ファイルを作り、PUT で rich snapshot に差し替える (id を固定)
+  const created = await (
+    await fetch(
+      new Request('http://localhost/files', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: file.name }),
+      }),
+    )
+  ).json();
+  // 実 id で rich snapshot に更新する。marker はまだ立てない
+  // (既存ファイル = snapshot 保存済み・未 migration。初回 open が migration を発火する)
+  const target = { ...file, id: created.id };
+  await fetch(
+    new Request(`http://localhost/files/${created.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(target),
+    }),
+  );
+  file.id = created.id as FileId;
+}
+
+async function openViaOplog(fileId: FileId): Promise<GraphFile> {
+  const res = await fetch(
+    new Request(`http://localhost/files/${fileId}/batches`),
+  );
+  const batches = await res.json();
+  return projectFile(batches, fileId);
+}
+
+/** projectFile が GraphFile へ再現する構造フィールドだけを正規化して取り出す */
+function structural(f: GraphFile) {
+  const byId = (a: { id: string }, b: { id: string }) =>
+    a.id.localeCompare(b.id);
+  return {
+    name: f.name,
+    description: f.description,
+    sheets: f.sheets.map((s) => ({
+      id: s.id,
+      name: s.name,
+      description: s.description,
+      nodes: [...s.nodes].sort(byId),
+      edges: [...s.edges].sort(byId),
+      layouts: [...(s.layouts ?? [])].sort((a, b) =>
+        (a.nodeId as string).localeCompare(b.nodeId as string),
+      ),
+      edgeLayouts: [...(s.edgeLayouts ?? [])].sort((a, b) =>
+        (a.edgeId as string).localeCompare(b.edgeId as string),
+      ),
+    })),
+  };
+}
+
+describe('W3d-4 read cutover e2e (daemon + projectFile)', () => {
+  it('1. 既存 snapshot を開くと migration→projectFile が構造を再現する', async () => {
+    const file = richSnapshot(u(900) as FileId);
+    await putSnapshot(file);
+
+    const projected = await openViaOplog(file.id);
+
+    // ファイルメタ・シート順・ノード・エッジ・レイアウトが snapshot と一致
+    expect(structural(projected)).toEqual(structural(file));
+    // シート順 (メイン → サブ) が保たれる
+    expect(projected.sheets.map((s) => s.name)).toEqual(['メイン', 'サブ']);
+  });
+
+  it('2. migration はべき等: 再オープンで同一 projection', async () => {
+    const file = richSnapshot(u(901) as FileId);
+    await putSnapshot(file);
+
+    const first = await openViaOplog(file.id);
+    const second = await openViaOplog(file.id);
+
+    expect(structural(second)).toEqual(structural(first));
+  });
+
+  it('3. 編集 (batch 追記) を再オープンで projection に反映する', async () => {
+    const file = richSnapshot(u(902) as FileId);
+    await putSnapshot(file);
+
+    // 一度開いて genesis の最大 clock を確認してから、その後に編集を積む
+    const before = await fetch(
+      new Request(`http://localhost/files/${file.id}/batches`),
+    );
+    const genesis = await before.json();
+    const maxClock = genesis.reduce(
+      (m: number, b: { clock: number }) => Math.max(m, b.clock),
+      0,
+    );
+
+    // nodeA (u(1)) の content を編集する batch を追記
+    const edit = {
+      id: u(5000),
+      actor: 'local',
+      clock: maxClock + 1,
+      timestamp: Date.now(),
+      sheetId: u(101),
+      ops: [{ kind: 'node.setContent', target: u(1), content: 'A-edited' }],
+    };
+    await fetch(
+      new Request(`http://localhost/files/${file.id}/batches`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify([edit]),
+      }),
+    );
+
+    const projected = await openViaOplog(file.id);
+    const nodeA = projected.sheets[0].nodes.find((n) => n.id === u(1));
+    expect(nodeA?.content).toBe('A-edited');
+  });
+
+  it('4. flag off (snapshot 直読) は最新 snapshot を返す (安全弁)', async () => {
+    const file = richSnapshot(u(903) as FileId);
+    await putSnapshot(file);
+    // migration を発火させる (op-log 側を正典化)
+    await openViaOplog(file.id);
+
+    // GET /files/:id = READ_FROM_OPLOG=false 相当の snapshot 直読経路
+    const res = await fetch(new Request(`http://localhost/files/${file.id}`));
+    const snapshot = await res.json();
+
+    // snapshot は migration で破壊されず、元の GraphFile を返す
+    expect(structural(snapshot)).toEqual(structural(file));
+  });
+});

--- a/src/shared/src/events/projectFile.bench.ts
+++ b/src/shared/src/events/projectFile.bench.ts
@@ -1,0 +1,165 @@
+/**
+ * W3d-3 レイテンシ実測 (投棄可ベンチ, step1-w3d-read-cutover.md §3.5)
+ *
+ * op-log 読取 cutover の受け入れゲート。`projectFile(batches)` の実行時間を
+ * 合成 batch (genesis + 増分編集) の規模 N = 100/500/1,000/5,000 で計測する。
+ * マルチシート (5 シート) 構成も含める。
+ *
+ * 予算 (§3.5): 典型ファイル (数百 batch) で projectFile < 50ms。
+ * 超過したら §3.6 の projection cache を W3d 内で導入する判断材料にする。
+ *
+ * 実行: `bun run src/shared/src/events/projectFile.bench.ts`
+ * (プロダクトコードではない。CI にも載せない。数値を PR に貼るための使い捨て。)
+ */
+
+import type { EdgeId, FileId, GraphFile, NodeId, SheetId } from '../schemas';
+import { graphFileToBatches } from './genesis';
+import { projectFile } from './project';
+import type { Batch, Op } from './unified';
+
+const uuid = (): string => crypto.randomUUID();
+
+/** N 個の node と概ね N 本の edge を持つシートを sheetCount 枚組み立てる */
+function buildGraphFile(
+  nodesPerSheet: number,
+  sheetCount: number,
+): { file: GraphFile; sheetNodeIds: NodeId[][]; sheetIds: SheetId[] } {
+  const sheetNodeIds: NodeId[][] = [];
+  const sheetIds: SheetId[] = [];
+  const sheets = [];
+  for (let s = 0; s < sheetCount; s++) {
+    const sheetId = uuid() as SheetId;
+    sheetIds.push(sheetId);
+    const nodeIds: NodeId[] = [];
+    const nodes = [];
+    const layouts = [];
+    for (let i = 0; i < nodesPerSheet; i++) {
+      const id = uuid() as NodeId;
+      nodeIds.push(id);
+      nodes.push({ id, content: `node ${i}` });
+      layouts.push({ nodeId: id, x: i * 10, y: i * 5, width: 120, height: 40 });
+    }
+    // 隣接ノードを繋ぐ edge を N-1 本
+    const edges = [];
+    for (let i = 0; i + 1 < nodesPerSheet; i++) {
+      edges.push({
+        id: uuid() as EdgeId,
+        source: nodeIds[i],
+        target: nodeIds[i + 1],
+        label: `e${i}`,
+      });
+    }
+    sheetNodeIds.push(nodeIds);
+    sheets.push({
+      id: sheetId,
+      name: `Sheet ${s + 1}`,
+      nodes,
+      edges,
+      layouts,
+      edgeLayouts: [],
+    });
+  }
+  return {
+    file: { id: uuid() as FileId, name: 'bench file', sheets },
+    sheetNodeIds,
+    sheetIds,
+  };
+}
+
+/**
+ * genesis batch に、実運用相当の増分編集 batch (1 op/batch) を追記して
+ * 合計 batch 数を targetTotal にする。編集はノード移動/内容変更を巡回で当てる。
+ */
+function synthBatches(
+  targetTotal: number,
+  nodesPerSheet: number,
+  sheetCount: number,
+): { batches: Batch[]; fileId: FileId } {
+  const { file, sheetNodeIds, sheetIds } = buildGraphFile(
+    nodesPerSheet,
+    sheetCount,
+  );
+  const genesis = graphFileToBatches(file);
+  const batches: Batch[] = [...genesis];
+  let clock = genesis.reduce((m, b) => Math.max(m, b.clock), 0) + 1;
+
+  // 残りを 1 op の増分編集 batch で埋める (既存ノードを巡回で編集)
+  let n = 0;
+  while (batches.length < targetTotal) {
+    const s = n % sheetCount;
+    const nodeIds = sheetNodeIds[s];
+    const nodeId = nodeIds[n % nodeIds.length];
+    const op: Op =
+      n % 2 === 0
+        ? {
+            kind: 'node.setLayout',
+            target: nodeId,
+            x: n % 500,
+            y: (n * 3) % 500,
+          }
+        : { kind: 'node.setContent', target: nodeId, content: `edit ${n}` };
+    batches.push({
+      id: uuid(),
+      actor: 'bench-actor',
+      clock: clock++,
+      timestamp: Date.now(),
+      sheetId: sheetIds[s],
+      ops: [op],
+    } as Batch);
+    n++;
+  }
+  return { batches, fileId: file.id };
+}
+
+/** median を返す (外れ値に強い代表値) */
+function median(xs: number[]): number {
+  const sorted = [...xs].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+}
+
+function bench(
+  label: string,
+  batches: Batch[],
+  fileId: FileId,
+  iterations: number,
+): void {
+  // ウォームアップ (JIT)
+  for (let i = 0; i < 5; i++) projectFile(batches, fileId);
+  const samples: number[] = [];
+  for (let i = 0; i < iterations; i++) {
+    const t0 = performance.now();
+    projectFile(batches, fileId);
+    samples.push(performance.now() - t0);
+  }
+  const med = median(samples);
+  const min = Math.min(...samples);
+  const max = Math.max(...samples);
+  const verdict = med < 50 ? 'OK' : 'OVER';
+  console.log(
+    `${label.padEnd(34)} median=${med.toFixed(2)}ms  min=${min.toFixed(2)}ms  max=${max.toFixed(2)}ms  [<50ms: ${verdict}]`,
+  );
+}
+
+const Ns = [100, 500, 1_000, 5_000];
+const ITER = 50;
+
+console.log('=== W3d-3 projectFile latency (single sheet, 200 nodes base) ===');
+for (const N of Ns) {
+  const { batches, fileId } = synthBatches(N, 200, 1);
+  bench(`N=${N} batches, 1 sheet`, batches, fileId, ITER);
+}
+
+console.log(
+  '\n=== W3d-3 projectFile latency (5 sheets, 100 nodes/sheet base) ===',
+);
+for (const N of Ns) {
+  const { batches, fileId } = synthBatches(N, 100, 5);
+  bench(`N=${N} batches, 5 sheets`, batches, fileId, ITER);
+}
+
+console.log(
+  `\n(iterations=${ITER}/case, warmup=5, median reported. 予算 §3.5: projectFile < 50ms)`,
+);


### PR DESCRIPTION
## 概要

step1 (操作ログ正典化) Phase 4 実配線 **W3d-3 + W3d-4** をまとめた PR。W3d-1 (server lazy migration, #159) / W3d-2 (client 読取切替 + フラグ, #160) がマージ済みの状態に、**レイテンシ実測 (cache 要否判定)** と **層をまたいだ実機 e2e 検証**を追加する。コード配線の変更はなく、ベンチ・テスト・ドキュメントのみ。

設計: `deepse/plans/step1-w3d-read-cutover.md` (§9 レイテンシ, §10 e2e 検証)。

## W3d-3 — projectFile レイテンシ実測 (`3022598`)

- 投棄可ベンチ `src/shared/src/events/projectFile.bench.ts` (CI 非搭載, `bun run` で実行)。
- 結果: 典型 (数百 batch) ~0.2ms = 予算 50ms の 1/200 以下、最悪 N=5000 で <1ms、batch 数に線形 (N=50000 でも 5.9ms)。
- **判定: §3.6 projection cache は不要** (W3d/W3e とも)。§8 の cache 要否をクローズ。

## W3d-4 — 読取 cutover の実機 e2e 検証

### 自動 e2e (デーモンレベル, `8ea101b`)
`src/server/src/readCutover.e2e.test.ts` — 実 HTTP (`server.fetch`) + 実 SQLite (`events.db`) + 実 snapshot (`storage.ts`) + client `projectFile` を一気通貫。4 ケース全 green:
1. 既存 snapshot open → lazy migration → projection が構造を再現
2. migration べき等 (再オープンで再 genesis しない)
3. 編集 (batch 追記) → 再オープンで反映
4. flag off (snapshot 直読) が migration 後も元 snapshot を返す (dual-read 安全弁健在)

### ドキュメント (`7460e70` §10.1 / `eecc7e7` §10.2)
- §10.1: 実デーモン HTTP 検証 (in-process `server.fetch` の外側、実ポート :3000 越し curl) の記録。
- §10.2: **ブラウザ目視 click-through を Chrome MCP で実機確認し全4項目パス**:
  1. **projection 描画** — snapshot だけの pre-W3 ファイルを開くと、触っていないファイルに genesis 3 batch が生成 = ブラウザ read が lazy migration を発火。ノード配置・ラベル付きエッジ・シートタブ正常描画。
  2. **編集の永続** — Markdown ノード追加 → op-log に `local` 追記 (clock4/5)、再オープンで残存かつ読取専用 (batch 不増)。
  3. **branch トグル** — アプリ内 React モーダルが従来通り起動→キャンセルで trunk 復帰 (§3.3 branch コード未変更)。
  4. **安全弁 (flag off)** — snapshot に判別マーカーを仕込み、`VITE_READ_FROM_OPLOG=false` の別ポートクライアントと対比。flag on=op-log 読取 / flag off=snapshot 直読 の切替を画面で確定。

## テスト

- 全 436 テスト green、lint / typecheck パス (pre-commit hook)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)